### PR TITLE
Disable NonAsciiCharacter Rule on verbatim strings

### DIFF
--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/NonAsciiCharactersAreEscapedInLiteralsRuleTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/NonAsciiCharactersAreEscapedInLiteralsRuleTests.cs
@@ -36,21 +36,22 @@ using System;
 class Test
 {{
     public static readonly string BadString = ""This has {0} and {1}, which are both bad."";
-    public static readonly string AnotherBadString = @""This has {0} and {1}, which are both bad."";
+    public static readonly string AnotherBadString = @""This has {0} and {1}, which are both bad, but we don't rewrite yet."";
     public const char BadChar = '{0}';
 }}
 ", '\u2713', "\U0001F308");
 
-            var expected = @"
+            var expected = string.Format(@"
 using System;
 
 class Test
-{
+{{
     public static readonly string BadString = ""This has \u2713 and \U0001F308, which are both bad."";
-    public static readonly string AnotherBadString = @""This has \u2713 and \U0001F308, which are both bad."";
+    public static readonly string AnotherBadString = @""This has {0} and {1}, which are both bad, but we don't rewrite yet."";
     public const char BadChar = '\u2713';
-}
-";
+}}
+", '\u2713', "\U0001F308");
+
             Verify(text, expected);
         }
 

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/NonAsciiCharactersAreEscapedInLiteralsRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/NonAsciiCharactersAreEscapedInLiteralsRule.cs
@@ -51,6 +51,13 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
             {
                 Debug.Assert(node.CSharpKind() == SyntaxKind.StringLiteralExpression);
 
+                if (node.Token.IsVerbatimStringLiteral())
+                {
+                    // We do not correctly rewrite verbatim string literals yet.  Once Issue 39 is
+                    // fixed we can remove this early out.
+                    return node;
+                }
+
                 if (HasNonAsciiCharacters(node.Token.Text))
                 {
                     string convertedText = EscapeNonAsciiCharacters(node.Token.Text);


### PR DESCRIPTION
I had hoped to fix this quickly, but other stuff came up and I didn't get a chance to and it's not looking like I will in the next few days, so disabling the rule against an issue seems like the next best thing for now.
