### PR TITLE
Add error handling do detect when MSBuild 14 is missing

### DIFF
--- a/src/CodeFormatter/Program.cs
+++ b/src/CodeFormatter/Program.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.MSBuild;
@@ -90,15 +91,31 @@ namespace CodeFormatter
 
             Console.CancelKeyPress += delegate { cts.Cancel(); };
 
-            RunAsync(
-                projectOrSolutionPath, 
-                ruleTypeBuilder.ToImmutableArray(),
-                fileNamesBuilder.ToImmutableArray(),
-                configBuilder.ToImmutableArray(),
-                copyrightHeader,
-                ct).Wait(ct);
-            Console.WriteLine("Completed formatting.");
-            return 0;
+            try
+            {
+                RunAsync(
+                    projectOrSolutionPath,
+                    ruleTypeBuilder.ToImmutableArray(),
+                    fileNamesBuilder.ToImmutableArray(),
+                    configBuilder.ToImmutableArray(),
+                    copyrightHeader,
+                    ct).Wait(ct);
+                Console.WriteLine("Completed formatting.");
+                return 0;
+            }
+            catch (AggregateException ex)
+            {
+                var typeLoadException = ex.InnerExceptions.FirstOrDefault() as ReflectionTypeLoadException;
+                if (typeLoadException == null)
+                    throw;
+
+                Console.WriteLine("ERROR: Type loading error detected. In order to run this tool you need either Visual Studio 2015 or Microsoft Build Tools 2015 tools installed.");
+                var messages = typeLoadException.LoaderExceptions.Select(e => e.Message).Distinct();
+                foreach (var message in messages)
+                    Console.WriteLine("- {0}", message);
+
+                return 1;
+            }
         }
 
         private static async Task RunAsync(


### PR DESCRIPTION
The code formatter currently just crashes with a type load exception if the MSBuild 14 is missing. Instead, it's better to detect this case and provide an actionable error message.

@jaredpar @Priya91 
