### PR TITLE
Added new rule for newline at end of file

### DIFF
--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Microsoft.DotNet.CodeFormatting.Tests.csproj
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Microsoft.DotNet.CodeFormatting.Tests.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Rules\CombinationTest.cs" />
     <Compile Include="Rules\ExplicitThisRuleTests.cs" />
     <Compile Include="Rules\ExplicitVisibilityRuleTests.cs" />
+    <Compile Include="Rules\HasNewLineAtEndOfFileFormattingRuleTests.cs" />
     <Compile Include="Rules\HasNewLineBeforeFirstNamespaceFormattingRuleTests.cs" />
     <Compile Include="Rules\HasNoIllegalHeadersFormattingRuleTests.cs" />
     <Compile Include="Rules\HasNewLineBeforeFirstUsingFormattingRuleTests.cs" />

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/HasNewLineAtEndOfFileFormattingRuleTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/HasNewLineAtEndOfFileFormattingRuleTests.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+
+namespace Microsoft.DotNet.CodeFormatting.Tests
+{
+    public class HasNewLineAtEndOfFileFormattingRuleTests : SyntaxRuleTestBase
+    {
+        internal override ISyntaxFormattingRule Rule
+        {
+            get { return new Rules.HasNewLineAtEndOfFileFormattingRule(); }
+        }
+
+        [Fact]
+        public void ShouldAddNewLine()
+        {
+            var source = "public class C { }";
+
+            var expected = "public class C { }\r\n";
+
+            Verify(source, expected);
+        }
+
+        [Fact]
+        public void ShouldRemoveExtraNewLines()
+        {
+            var source = "public class C { }\r\n\r\n\n\r\n\n\r";
+
+            var expected = "public class C { }\r\n";
+
+            Verify(source, expected);
+        }
+
+        [Fact]
+        public void ShouldNotCareAboutExistingCarriageReturn()
+        {
+            var source = "public class C { }\r";
+
+            var expected = "public class C { }\r\n";
+
+            Verify(source, expected);
+        }
+
+        [Fact]
+        public void ShouldNotCareAboutExistingLineFeed()
+        {
+            var source = "public class C { }\n";
+
+            var expected = "public class C { }\r\n";
+
+            Verify(source, expected);
+        }
+
+        [Fact]
+        public void ShouldHandleEmptyDocument()
+        {
+            var source = string.Empty;
+
+            var expected = "\r\n";
+
+            Verify(source, expected);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.CodeFormatting/Microsoft.DotNet.CodeFormatting.csproj
+++ b/src/Microsoft.DotNet.CodeFormatting/Microsoft.DotNet.CodeFormatting.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Rules\BraceNewLineRule.cs" />
     <Compile Include="Rules\ExplicitVisibilityRule.cs" />
     <Compile Include="Rules\HasCopyrightHeaderFormattingRule.cs" />
+    <Compile Include="Rules\HasNewLineAtEndOfFileFormattingRule.cs" />
     <Compile Include="Rules\HasNewLineBeforeFirstNamespaceFormattingRule.cs" />
     <Compile Include="Rules\HasNewLineBeforeFirstUsingFormattingRule.cs" />
     <Compile Include="Rules\HasNoIllegalHeadersFormattingRule.cs" />

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/HasNewLineAtEndOfFileFormattingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/HasNewLineAtEndOfFileFormattingRule.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Microsoft.DotNet.CodeFormatting.Rules
+{
+    [SyntaxRuleOrder(SyntaxRuleOrder.HasNewLineAtEndOfFile)]
+    internal sealed class HasNewLineAtEndOfFileFormattingRule : ISyntaxFormattingRule
+    {
+        public SyntaxNode Process(SyntaxNode syntaxRoot)
+        {
+            var node = syntaxRoot.DescendantNodes().LastOrDefault();
+
+            if (node != null)
+            {
+                syntaxRoot = syntaxRoot.ReplaceNode(node, RemoveNewLines(node));
+            }
+
+            var token = syntaxRoot.DescendantTokens().Single(x => x.IsKind(SyntaxKind.EndOfFileToken));
+
+            return syntaxRoot.ReplaceToken(token, AdjustNewLines(token));
+        }
+
+        private static SyntaxNode RemoveNewLines(SyntaxNode node)
+        {
+            var newTrivia = Enumerable.Empty<SyntaxTrivia>();
+
+            if (node.HasTrailingTrivia)
+            {
+                newTrivia = node.GetTrailingTrivia().Where(x => !x.IsKind(SyntaxKind.EndOfLineTrivia));
+            }
+
+            return node.WithTrailingTrivia(newTrivia);
+        }
+
+        private static SyntaxToken AdjustNewLines(SyntaxToken token)
+        {
+            var newTrivia = Enumerable.Empty<SyntaxTrivia>();
+
+            if (token.HasLeadingTrivia)
+            {
+                newTrivia = token.LeadingTrivia.Where(x => !x.IsKind(SyntaxKind.EndOfLineTrivia));
+            }
+
+            return token.WithLeadingTrivia(newTrivia.AddNewLine());
+        }
+    }
+}

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/RuleOrder.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/RuleOrder.cs
@@ -19,6 +19,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
         public const int HasNewLineBeforeFirstNamespaceFormattingRule = 5;
         public const int BraceNewLineRule = 6;
         public const int NonAsciiChractersAreEscapedInLiterals = 7;
+        public const int HasNewLineAtEndOfFile = 8;
     }
 
     // Please keep these values sorted by number, not rule name.    


### PR DESCRIPTION
This does the following:
  1. Removes all trailing EndOfLine trivia from the last node of the document.
  2. Replaces all leading EndOfLine trivia on the EndOfFile token with a single CarriageReturnLineFeed trivia.

Fixes #54