### PR TITLE
Add rules for formatting attributes

### DIFF
--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Microsoft.DotNet.CodeFormatting.Tests.csproj
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Microsoft.DotNet.CodeFormatting.Tests.csproj
@@ -105,6 +105,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CodeFormattingTestBase.cs" />
+    <Compile Include="Rules\AttributeNoParenthesesRuleTests.cs" />
+    <Compile Include="Rules\AttributeSeparateListsRuleTests.cs" />
     <Compile Include="Rules\BracesRuleTests.cs" />
     <Compile Include="Rules\CombinationTest.cs" />
     <Compile Include="Rules\ExplicitThisRuleTests.cs" />

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/AttributeNoParenthesesRuleTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/AttributeNoParenthesesRuleTests.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+using Microsoft.DotNet.CodeFormatting.Rules;
+
+using Xunit;
+
+namespace Microsoft.DotNet.CodeFormatting.Tests
+{
+    public class AttributeNoParenthesesRuleTests : SyntaxRuleTestBase
+    {
+        internal override ISyntaxFormattingRule Rule
+        {
+            get { return new AttributeNoParenthesesRule(); }
+        }
+
+        [Fact]
+        public void RemoveParenthesesFromAttributes()
+        {
+            var text = @"
+[assembly: GlobalAtt()]
+[assembly: GlobalAtt(1)]
+
+namespace Namespace1
+{
+    [Serializable(), Category(2), Rule]
+    class Class1
+    {
+        [return: SomeAtt(]
+        [AnotherAtt(1), YetAnotherAtt(), YetAnotherAtt]
+        public int SomeMethod(SyntaxNode syntaxRoot)
+        {
+            return 42;
+        }
+    }
+}
+";
+            var expected = @"
+[assembly: GlobalAtt]
+[assembly: GlobalAtt(1)]
+
+namespace Namespace1
+{
+    [Serializable, Category(2), Rule]
+    class Class1
+    {
+        [return: SomeAtt]
+        [AnotherAtt(1), YetAnotherAtt, YetAnotherAtt]
+        public int SomeMethod(SyntaxNode syntaxRoot)
+        {
+            return 42;
+        }
+    }
+}
+";
+            Verify(text, expected);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/AttributeSeparateListsRuleTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/AttributeSeparateListsRuleTests.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+using Microsoft.DotNet.CodeFormatting.Rules;
+
+using Xunit;
+
+namespace Microsoft.DotNet.CodeFormatting.Tests
+{
+    public class AttributeSeparateListsRuleTests : SyntaxRuleTestBase
+    {
+        internal override ISyntaxFormattingRule Rule
+        {
+            get { return new AttributeSeparateListsRule(); }
+        }
+
+        [Fact]
+        public void ParameterAttributeListsAreNotSeparated()
+        {
+            var text = @"
+namespace Namespace1
+{
+    class Class1
+    {
+        public int SomeMethod([In, Out]SomeType someParameter)
+        {
+            return 42;
+        }
+    }
+}";
+            Verify(text, text);
+        }
+
+        [Fact]
+        public void AttributeListsAreSeparated()
+        {
+            var text = @"
+[assembly: FileVersion(1, 1), AssemblyVersion(1, 1)]
+namespace Namespace1
+{
+    [
+        Serializable,       // Good, isn't?
+        DefaultValue(1)     // Is this the right value?
+    ]
+    class Class1
+    {
+        [Serializable, DefaultValue(1)]
+        public int SomeMethod(SomeType someParameter)
+        {
+            return 42;
+        }
+    }
+}";
+
+            var expected = @"
+[assembly: FileVersion(1, 1)]
+[assembly: AssemblyVersion(1, 1)]
+namespace Namespace1
+{
+
+    [Serializable]       // Good, isn't?
+    [DefaultValue(1)]     // Is this the right value?
+
+    class Class1
+    {
+        [Serializable]
+        [DefaultValue(1)]
+        public int SomeMethod(SomeType someParameter)
+        {
+            return 42;
+        }
+    }
+}";
+            Verify(text, expected);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.CodeFormatting/Microsoft.DotNet.CodeFormatting.csproj
+++ b/src/Microsoft.DotNet.CodeFormatting/Microsoft.DotNet.CodeFormatting.csproj
@@ -86,6 +86,8 @@
     <Compile Include="RuleOrderAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="IOrderMetadata.cs" />
+    <Compile Include="Rules\AttributeNoParenthesesRule.cs" />
+    <Compile Include="Rules\AttributeSeparateListsRule.cs" />
     <Compile Include="Rules\BraceNewLineRule.cs" />
     <Compile Include="Rules\ExplicitVisibilityRule.cs" />
     <Compile Include="Rules\HasCopyrightHeaderFormattingRule.cs" />

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/AttributeNoParenthesesRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/AttributeNoParenthesesRule.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.DotNet.CodeFormatting.Rules
+{
+    [SyntaxRuleOrder(SyntaxRuleOrder.AttributeNoParenthesesRule)]
+    internal sealed class AttributeNoParenthesesRule : ISyntaxFormattingRule
+    {
+        public SyntaxNode Process(SyntaxNode syntaxRoot)
+        {
+            var attributes = syntaxRoot.DescendantNodes()
+                                       .OfType<AttributeSyntax>()
+                                       .Where(a => a.ArgumentList != null &&
+                                                   a.ArgumentList.Arguments.Count == 0 &&
+                                                   (!a.ArgumentList.OpenParenToken.IsMissing || !a.ArgumentList.CloseParenToken.IsMissing));
+
+            return syntaxRoot.ReplaceNodes(attributes, (a, n) => a.WithArgumentList(null));
+        }
+    }
+}

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/AttributeSeparateListsRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/AttributeSeparateListsRule.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.DotNet.CodeFormatting.Rules
+{
+    [SyntaxRuleOrder(SyntaxRuleOrder.AttributeSeparateListsRule)]
+    internal sealed class AttributeSeparateListsRule : ISyntaxFormattingRule
+    {
+        public SyntaxNode Process(SyntaxNode syntaxRoot)
+        {
+            var rewriter = new AttributeListRewriter();
+            return rewriter.Visit(syntaxRoot);
+        }
+
+        private sealed class AttributeListRewriter : CSharpSyntaxRewriter
+        {
+            public override SyntaxNode VisitParameter(ParameterSyntax node)
+            {
+                // We don't want to flatten the attribute lists for parameters. Those are
+                // usually short, such as [In, Out] and collapsing them can actually
+                // improve readability.
+                return node;
+            }
+
+            public override SyntaxList<TNode> VisitList<TNode>(SyntaxList<TNode> list)
+            {
+                list = base.VisitList(list);
+
+                if (typeof (TNode) != typeof (AttributeListSyntax))
+                    return list;
+
+                var attributeLists = (SyntaxList<AttributeListSyntax>) (object) list;
+                return (SyntaxList<TNode>) (object) VisitAttributeLists(attributeLists);
+            }
+
+            private static SyntaxList<AttributeListSyntax> VisitAttributeLists(SyntaxList<AttributeListSyntax> attributeLists)
+            {
+                var result = new List<AttributeListSyntax>();
+
+                foreach (var attributeList in attributeLists)
+                {
+                    var firstIndex = result.Count;
+
+                    for (var i = 0; i < attributeList.Attributes.Count; i++)
+                    {
+                        var attribute = attributeList.Attributes[i];
+                        var separatorTrivia = i < attributeList.Attributes.Count - 1
+                                                ? attributeList.Attributes.GetSeparator(i).GetAllTrivia()
+                                                : Enumerable.Empty<SyntaxTrivia>();
+
+                        var attributeWithoutTrivia = attribute.WithoutLeadingTrivia().WithoutTrailingTrivia();
+                        var singletonList = SyntaxFactory.AttributeList(attributeList.Target, SyntaxFactory.SeparatedList(new[] { attributeWithoutTrivia }))
+                                                         .WithLeadingTrivia(attribute.GetLeadingTrivia())
+                                                         .WithTrailingTrivia(attribute.GetTrailingTrivia().Concat(separatorTrivia));
+                        result.Add(singletonList);
+                    }
+
+                    var lastIndex = result.Count - 1;
+
+                    var leadingTrivia = attributeList.GetLeadingTrivia()
+                                            .Concat(attributeList.OpenBracketToken.TrailingTrivia)
+                                            .Concat(result[firstIndex].GetLeadingTrivia());
+
+                    var trailingTrivia = result[lastIndex].GetTrailingTrivia()
+                                            .Concat(attributeList.CloseBracketToken.LeadingTrivia)
+                                            .Concat(attributeList.GetTrailingTrivia());
+
+                    result[firstIndex] = result[firstIndex].WithLeadingTrivia(leadingTrivia);
+                    result[lastIndex] = result[lastIndex].WithTrailingTrivia(trailingTrivia);
+                }
+
+                return SyntaxFactory.List(result);
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/RuleOrder.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/RuleOrder.cs
@@ -20,6 +20,8 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
         public const int BraceNewLineRule = 6;
         public const int NonAsciiChractersAreEscapedInLiterals = 7;
         public const int TestAssertTrueOrFalseRule = 8;
+        public const int AttributeNoParenthesesRule = 9;
+        public const int AttributeSeparateListsRule = 10;
     }
 
     // Please keep these values sorted by number, not rule name.    


### PR DESCRIPTION
This adds two additional rules for dealing with attributes:
### Removing superfluous parentheses

It's conventional to omit parentheses when the attribute doesn't take any arguments, for example:

``` CSharp
[target: SomeAtt()]
```

becomes

``` CSharp
[target: SomeAtt]
```
### Separating attribute lists

Most folks only use a single attribute in an attribute list, although the syntax supports multiple attributes. In most cases, putting attributes in separate lists is beneficial because it improves readability and allows better diffs.

This changes code like this:

``` CSharp
[Serializable, Category("Catagory"), DefaultValue(1)]
```

to 

``` CSharp
[Serializable]
[Category("Catagory")]
[DefaultValue(1)]
```

The only exception are attributes for parameters. In interop code, it's quite common to mark parameters with `[In]` and `[Out]`. Since the attributes are usually written inline, i.e. not on separate lines, it's actually beneficial to no split them into separate lists.

This means that code like this is left as-is:

``` CSharp
void NativeFun([In, Out] int* target)
```
