### PR TITLE
Fix multiline copyright header rule

### DIFF
--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/CopyrightHeaderRuleTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/CopyrightHeaderRuleTests.cs
@@ -37,6 +37,25 @@ class C
         }
 
         [Fact]
+        public void CSharpSimpleMultiline()
+        {
+            _options.CopyrightHeader = ImmutableArray.Create("test1", "test2");
+            var source = @"
+class C
+{
+}";
+
+            var expected = @"// test1
+// test2
+
+class C
+{
+}";
+            Verify(source, expected);
+
+        }
+
+        [Fact]
         public void CSharpPreserveExisting()
         {
             _options.CopyrightHeader = ImmutableArray.Create("test");
@@ -47,6 +66,62 @@ class C
 }";
 
             var expected = @"// test
+
+class C
+{
+}";
+            Verify(source, expected);
+
+        }
+
+        [Fact]
+        public void CSharpPreserveExistingMultiline()
+        {
+            _options.CopyrightHeader = ImmutableArray.Create("test1", "test2");
+            var source = @"// test1
+// test2
+
+class C
+{
+}";
+
+            var expected = @"// test1
+// test2
+
+class C
+{
+}";
+            Verify(source, expected);
+
+        }
+
+        [Fact]
+        public void CSharpPreserveExistingWithCommentMultiline()
+        {
+            _options.CopyrightHeader = ImmutableArray.Create("test1", "test2");
+            var source = @"// test1
+// test2
+
+
+
+
+
+// test3
+
+
+class C
+{
+}";
+
+            var expected = @"// test1
+// test2
+
+
+
+
+
+// test3
+
 
 class C
 {

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.CSharp.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.CSharp.cs
@@ -32,11 +32,14 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
                 return trivia.Kind() == SyntaxKind.SingleLineCommentTrivia;
             }
 
-            protected override bool IsWhiteSpaceOrNewLine(SyntaxTrivia trivia)
+            protected override bool IsWhitespace(SyntaxTrivia trivia)
             {
-                return
-                    trivia.Kind() == SyntaxKind.WhitespaceTrivia ||
-                    trivia.Kind() == SyntaxKind.EndOfLineTrivia;
+                return trivia.Kind() == SyntaxKind.WhitespaceTrivia;
+            }
+
+            protected override bool IsNewLine(SyntaxTrivia trivia)
+            {
+                return trivia.Kind() == SyntaxKind.EndOfLineTrivia;
             }
 
             protected override SyntaxTrivia CreateLineComment(string commentText)

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.VisualBasic.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.VisualBasic.cs
@@ -31,11 +31,14 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
                 return trivia.Kind() == SyntaxKind.CommentTrivia;
             }
 
-            protected override bool IsWhiteSpaceOrNewLine(SyntaxTrivia trivia)
+            protected override bool IsWhitespace(SyntaxTrivia trivia)
             {
-                return
-                    trivia.Kind() == SyntaxKind.WhitespaceTrivia ||
-                    trivia.Kind() == SyntaxKind.EndOfLineTrivia;
+                return trivia.Kind() == SyntaxKind.WhitespaceTrivia;
+            }
+
+            protected override bool IsNewLine(SyntaxTrivia trivia)
+            {
+                return trivia.Kind() == SyntaxKind.EndOfLineTrivia;
             }
 
             protected override SyntaxTrivia CreateLineComment(string commentText)

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.cs
@@ -79,6 +79,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
                 {
                     headerList.Add(GetCommentText(triviaList[i].ToFullString()));
                     i++;
+                    MoveToNextLineOrTrivia(triviaList, ref i);
                 }
 
                 return headerList;
@@ -113,7 +114,25 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
 
             private void MovePastBlankLines(SyntaxTriviaList list, ref int index)
             {
-                while (index < list.Count && IsWhiteSpaceOrNewLine(list[index]))
+                while (index < list.Count && (IsWhitespace(list[index]) || IsNewLine(list[index])))
+                {
+                    index++;
+                }
+            }
+            
+            private void MoveToNextLineOrTrivia(SyntaxTriviaList list, ref int index)
+            {
+                MovePastWhitespaces(list, ref index);
+
+                if (index < list.Count && IsNewLine(list[index]))
+                {
+                    index++;
+                }
+            }
+
+            private void MovePastWhitespaces(SyntaxTriviaList list, ref int index)
+            {
+                while (index < list.Count && IsWhitespace(list[index]))
                 {
                     index++;
                 }
@@ -123,7 +142,8 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
 
             protected abstract bool IsLineComment(SyntaxTrivia trivia);
 
-            protected abstract bool IsWhiteSpaceOrNewLine(SyntaxTrivia trivia);
+            protected abstract bool IsWhitespace(SyntaxTrivia trivia);
+            protected abstract bool IsNewLine(SyntaxTrivia trivia);
 
             protected abstract SyntaxTrivia CreateLineComment(string commentText);
 


### PR DESCRIPTION
Fix a problem where some lines of multiline header are repeated during the formatting already formmated code.

I.e:
```
// test1
// test2
```

was formatted to:
```
// test1
// test2

// test1
// test2
```

When using real headers some of those lines are removed as they are treated as "old" header. I.e:
```
// Copyright blah
// License X
```

was being formatted to:
```
// Copyright blah
// License X

// License blah
```