### PR TITLE
Fix F5

### DIFF
--- a/build.props
+++ b/build.props
@@ -4,9 +4,8 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <OutDir Condition="'$(OutDir)' == ''">$(MsBuildThisFileDirectory)bin\</OutDir>
-    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(MsBuildThisFileDirectory)obj\$(MsBuildProjectName)\$(Configuration)\</IntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)' == ''">$(IntermediateOutputPath)</OutputPath>
+    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(MsBuildThisFileDirectory)obj\$(MSBuildProjectName)\$(Configuration)\</IntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)' == ''">$(MsBuildThisFileDirectory)bin\$(MSBuildProjectName)\$(Configuration)\</OutputPath>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <RestorePackages>true</RestorePackages>

--- a/src/CodeFormatter/CodeFormatter.csproj
+++ b/src/CodeFormatter/CodeFormatter.csproj
@@ -119,7 +119,7 @@
   <Target Name="BeforeBuild">
   </Target>  -->
   <Target Name="AfterBuild">
-    <Copy SourceFiles="$(ProjectDir)IllegalHeaders.md" DestinationFolder="$(OutDir)" ContinueOnError="true" />
-    <Copy SourceFiles="$(ProjectDir)CopyrightHeader.md" DestinationFolder="$(OutDir)" ContinueOnError="true" />
+    <Copy SourceFiles="$(ProjectDir)IllegalHeaders.md" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
+    <Copy SourceFiles="$(ProjectDir)CopyrightHeader.md" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
   </Target>
 </Project>


### PR DESCRIPTION
The build.props file was setting OutputPath to IntermediateOutputPath.
This caused operations like F5 to grab from the obj directory which
isn't correct.  It needs to grab it from the bin directory.

closes #94