### PR TITLE
Fix issue if a file leading trivia starts with the copyright header

### DIFF
--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/CopyrightHeaderRuleTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/CopyrightHeaderRuleTests.cs
@@ -164,6 +164,28 @@ class C
         }
 
         [Fact]
+        public void CSharpHeaderBeginsWithTargetHeader()
+        {
+            _options.CopyrightHeader = ImmutableArray.Create("// test", "// test2");
+            var source = @"// test
+// test2
+// file summary
+
+class C
+{
+}";
+
+            var expected = @"// test
+// test2
+// file summary
+
+class C
+{
+}";
+            Verify(source, expected);
+        }
+
+        [Fact]
         public void VisualBasicSimple()
         {
             _options.CopyrightHeader = ImmutableArray.Create("test");

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
         private abstract class CommonRule
         {
             /// <summary>
-            /// This is the normalized copyright header that has no comment delimeters.
+            /// This is the normalized copyright header that has no comment delimiters.
             /// </summary>
             private readonly ImmutableArray<string> _header;
 
@@ -43,7 +43,18 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
             private bool HasCopyrightHeader(SyntaxNode syntaxNode)
             {
                 var existingHeader = GetExistingHeader(syntaxNode.GetLeadingTrivia());
-                return _header.SequenceEqual(existingHeader);
+                return SequnceStartsWith(_header, existingHeader);
+            }
+
+            private bool SequnceStartsWith(ImmutableArray<string> header, List<string> existingHeader)
+            {
+                // Only try if the existing header is at least as long as the new copyright header
+                if (existingHeader.Count >= header.Count())
+                {
+                    return !header.Where((headerLine, i) => existingHeader[i] != headerLine).Any();
+                }
+
+                return false;
             }
 
             private SyntaxNode AddCopyrightHeader(SyntaxNode syntaxNode)


### PR DESCRIPTION
This should fix issues causing the file header to be messed up when the copyright header is already at the top of the file. See Issue #96 for details.