### PR TITLE
Change CopyrightHeaderRule order to run later

### DIFF
--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/CombinationTest.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/CombinationTest.cs
@@ -266,5 +266,38 @@ internal class C
 
             Verify(source, expected, runFormatter: false);
         }
+
+        [Fact]
+        public void CSharpHeaderCorrectAfterMovingUsings()
+        {
+
+            var source = @"
+namespace Microsoft.Build.UnitTests
+{
+    using System;
+    using System.Reflection;
+ 
+    public class Test
+    {
+        public void RequiredRuntimeAttribute() 
+       {}
+    }
+}";
+            var expected = @"// header
+
+using System;
+using System.Reflection;
+
+namespace Microsoft.Build.UnitTests
+{
+    public class Test
+    {
+        public void RequiredRuntimeAttribute()
+        { }
+    }
+}";
+
+            Verify(source, expected);
+        }
     }
 }

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/RuleOrder.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/RuleOrder.cs
@@ -13,11 +13,11 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
     internal static class SyntaxRuleOrder
     {
         public const int HasNoCustomCopyrightHeaderFormattingRule = 1;
-        public const int CopyrightHeaderRule = 2;
-        public const int UsingLocationFormattingRule = 3;
-        public const int NewLineAboveFormattingRule = 4;
-        public const int BraceNewLineRule = 6;
-        public const int NonAsciiChractersAreEscapedInLiterals = 7;
+        public const int UsingLocationFormattingRule = 2;
+        public const int NewLineAboveFormattingRule = 3;
+        public const int BraceNewLineRule = 4;
+        public const int NonAsciiChractersAreEscapedInLiterals = 5;
+        public const int CopyrightHeaderRule = 6;
     }
 
     // Please keep these values sorted by number, not rule name.    


### PR DESCRIPTION
Fix for Issue #78

When moving the using block outside of a namespace declaration, the copyright header would end up lower in the file. On the next run, it would add another one. This change just changes the copyright rule to run later.