### PR TITLE
Readonly field formatter

### DIFF
--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Microsoft.DotNet.CodeFormatting.Tests.csproj
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Microsoft.DotNet.CodeFormatting.Tests.csproj
@@ -68,6 +68,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
@@ -113,6 +114,7 @@
     <Compile Include="Rules\NewLineAboveRuleTests.cs" />
     <Compile Include="Rules\PrivateFieldNamingRuleTests.cs" />
     <Compile Include="Rules\NonAsciiCharactersAreEscapedInLiteralsRuleTests.cs" />
+    <Compile Include="Rules\MarkReadonlyFieldTests.cs" />
     <Compile Include="Rules\UsingLocationRuleTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/MarkReadonlyFieldTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/MarkReadonlyFieldTests.cs
@@ -1,0 +1,407 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+
+using Xunit;
+
+namespace Microsoft.DotNet.CodeFormatting.Tests
+{
+    /// <summary>
+    /// Test that fields are correctly identified as readonly.
+    /// </summary>
+    public class MarkReadonlyFieldTests : GlobalSemanticRuleTestBase
+    {
+        internal override IGlobalSemanticFormattingRule Rule
+        {
+            get { return new Rules.MarkReadonlyFieldsRule(); }
+        }
+
+        protected override IEnumerable<MetadataReference> GetSolutionMetadataReferences()
+        {
+            foreach (MetadataReference reference in base.GetSolutionMetadataReferences())
+            {
+                yield return reference;
+            }
+
+            yield return MetadataReference.CreateFromAssembly(typeof(ImportAttribute).Assembly);
+        }
+
+        // In general a single sting with "READONLY" in it is used
+        // for the tests to simplify the before/after comparison
+        // The Original method will remove it, and the Readonly will replace it
+        // with the keyword
+
+        [Fact]
+        public void TestIgnoreExistingReadonlyField()
+        {
+            string text = @"
+class C
+{
+    private readonly int alreadyFine;
+}
+";
+            Verify(Original(text), Readonly(text));
+        }
+
+        [Fact]
+        public void TestMarkReadonlyWithNoReferences()
+        {
+            string text = @"
+class C
+{
+    private READONLY int read;
+}
+";
+            Verify(Original(text), Readonly(text));
+        }
+
+        [Fact]
+        public void TestMarkReadonlyInternalWithNoReferences()
+        {
+            string text = @"
+class C
+{
+    internal READONLY int read;
+}
+";
+            Verify(Original(text), Readonly(text));
+        }
+
+        [Fact]
+        public void TestIgnoredReadonlyInternalWithNoReferencesByInternalsVisibleTo()
+        {
+            string text = @"
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute(""Some.Other.Assembly"")]
+class C
+{
+    internal int exposed;
+}
+";
+            Verify(Original(text), Readonly(text));
+        }
+
+        [Fact]
+        public void TestIgnoredPublic()
+        {
+            string text = @"
+public class C
+{
+    public int exposed;
+}
+";
+            Verify(Original(text), Readonly(text));
+        }
+
+        [Fact]
+        public void TestMarkedPublicInInternalClass()
+        {
+            string text = @"
+internal class C
+{
+    public READONLY int notExposed;
+}
+";
+            Verify(Original(text), Readonly(text));
+        }
+
+        [Fact]
+        public void TestIgnoredReadonlyWithWriteReferences()
+        {
+            string text = @"
+class C
+{
+    private int wrote;
+
+    public void T()
+    {
+        wrote = 5;
+    }
+}
+";
+            Verify(Original(text), Readonly(text));
+        }
+
+        [Fact]
+        public void TestIgnoredReadonlyWithCompoundWriteReferences()
+        {
+            string text = @"
+class C
+{
+    private int wrote;
+
+    public void T()
+    {
+        wrote += 5;
+    }
+}
+";
+            Verify(Original(text), Readonly(text));
+        }
+
+        [Fact]
+        public void TestMarkReadonlyWithReadReferences()
+        {
+            string text = @"
+class C
+{
+    private READONLY int read;
+    private int writen;
+
+    public void T()
+    {
+        int x = change;
+        x = read;
+        writen = read;
+        X(read);
+    }
+
+    public void X(int a)
+    {
+    }
+}
+";
+            Verify(Original(text), Readonly(text));
+        }
+
+        [Fact]
+        public void TestIgnoredReadonlyWithRefArgument()
+        {
+            string text = @"
+class C
+{
+    private int read;
+
+    public void M(ref int a)
+    {
+    }
+
+    public void T()
+    {
+        M(ref read);
+    }
+}
+";
+            Verify(Original(text), Readonly(text));
+        }
+
+        [Fact]
+        public void TestIgnoredReadonlyWithOutArgument()
+        {
+            string text = @"
+class C
+{
+    private int read;
+
+    public void N(out int a)
+    {
+    }
+
+    public void T()
+    {
+        N(out read);
+    }
+}
+";
+            Verify(Original(text), Readonly(text));
+        }
+
+        [Fact]
+        public void TestIgnoredReadonlyWithExternRefArgument()
+        {
+            string text = @"
+class C
+{
+    private int read;
+
+    private extern void M(ref C c);
+}
+";
+            Verify(Original(text), Readonly(text));
+        }
+
+        [Fact]
+        public void TestIgnoredReadonlyWithMethodCall()
+        {
+            string text = @"
+struct S
+{
+    public void T() { }
+}
+
+class C
+{
+    private S called;
+
+    public void T()
+    {
+        called.T();
+    }
+}
+";
+            Verify(Original(text), Readonly(text));
+        }
+
+        [Fact]
+        public void TestMarkReadonlyWithPrimitiveMethodCall()
+        {
+            string text = @"
+
+class C
+{
+    private READONLY int called;
+
+    public void T()
+    {
+        string s = called.ToString();
+    }
+}
+";
+            Verify(Original(text), Readonly(text));
+        }
+
+        [Fact]
+        public void TestIgnoredImportedField()
+        {
+            string text = @"
+using System.ComponentModel.Composition;
+
+public interface ITest
+{
+}
+
+[Export(typeof(ITest))]
+public class Test : ITest
+{
+}
+
+class C
+{
+    [Import]
+    private ITest imported;
+}
+";
+            Verify(Original(text), Readonly(text));
+        }
+
+        [Fact]
+        public void TestMarkReadonlyWithWriteReferencesInConstructor()
+        {
+            string text = @"
+class C
+{
+    private READONLY int read;
+
+    public C()
+    {
+        read = 5;
+        M(ref read);
+        N(out read);
+    }
+
+    public void M(ref int a)
+    {
+    }
+
+    public void N(out int a)
+    {
+    }
+}
+";
+            Verify(Original(text), Readonly(text));
+        }
+
+        [Fact]
+        public void TestIgnoreReadonlyWithDelegateReferencesInConstructor()
+        {
+            string text = @"
+class C
+{
+    private int wrote;
+
+    public C()
+    {
+        Action a = delegate { wrote = 5 };
+    }
+}
+";
+            Verify(Original(text), Readonly(text));
+        }
+
+        [Fact]
+        public void TestIgnoreStaticReadonlyWithWriteReferencesInInstanceConstructor()
+        {
+            string text = @"
+class C
+{
+    private static int wrote;
+
+    public C()
+    {
+        wrote = 5;
+    }
+}
+";
+            Verify(Original(text), Readonly(text));
+        }
+
+        [Fact]
+        public void TestMultipleFiles()
+        {
+            string[] text =
+            {
+                @"
+class C1
+{
+    internal READONLY int read;
+    internal int wrote;
+
+    public void M(C2 c)
+    {
+        c.wrote = 5;
+        int x = c.read;
+    }
+}
+",
+                @"
+class C2
+{
+    internal READONLY int read;
+    internal int wrote;
+
+    public void M(C1 c)
+    {
+        c.wrote = 5;
+        int x = c.read;
+    }
+}
+"
+            };
+            Verify(Original(text), Readonly(text), true, LanguageNames.CSharp);
+        }
+
+        private static string Original(string text)
+        {
+            return text.Replace("READONLY ", "");
+        }
+
+        private static string Readonly(string text)
+        {
+            return text.Replace("READONLY ", "readonly ");
+        }
+
+        private static string[] Original(string[] text)
+        {
+            return text.Select(Original).ToArray();
+        }
+
+        private static string[] Readonly(string[] text)
+        {
+            return text.Select(Readonly).ToArray();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.CodeFormatting/Microsoft.DotNet.CodeFormatting.csproj
+++ b/src/Microsoft.DotNet.CodeFormatting/Microsoft.DotNet.CodeFormatting.csproj
@@ -85,7 +85,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="NameHelper.cs" />
     <Compile Include="ResponseFileWorkspace.cs" />
+    <Compile Include="Rules\MarkReadonlyFieldsRule.cs" />
+    <Compile Include="SemaphoreLock.cs" />
     <Compile Include="SyntaxUtil.cs" />
     <Compile Include="Filters\FilenameFilter.cs" />
     <Compile Include="Filters\UsableFileFilter.cs" />

--- a/src/Microsoft.DotNet.CodeFormatting/NameHelper.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/NameHelper.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.DotNet.CodeFormatting
+{
+    /// <summary>
+    /// Commonly used name functions
+    /// </summary>
+    internal static class NameHelper
+    {
+        /// <summary>
+        /// Get the full name of a symbol. So a field might look like
+        /// "OuterNamespace.Inner.ClassName.FieldName"
+        /// </summary>
+        /// <param name="symbol">symbol to get name of</param>
+        /// <returns>Full display name for a symbol</returns>
+        internal static string GetFullName(ISymbol symbol)
+        {
+            return GetFullName(symbol.ContainingType) + "." + symbol.Name;
+        }
+
+        /// <summary>
+        /// Get the full name of a type. i.e. "OuterNamespace.Inner.ClassName"
+        /// </summary>
+        /// <param name="type">type to get name of</param>
+        /// <returns>Full display name for a type</returns>
+        internal static string GetFullName(INamedTypeSymbol type)
+        {
+            if (type.ContainingType != null)
+            {
+                return GetFullName(type.ContainingType) + "+" + type.Name;
+            }
+
+            return GetFullName(type.ContainingNamespace) + "." + type.Name;
+        }
+
+        /// <summary>
+        /// Get the full name of a namespace. i.e. "OuterNamespace.Inner.ClassName"
+        /// </summary>
+        /// <param name="namespaceSymbol">namespace to get name of</param>
+        /// <returns>Full display name for a namespaceSymbol</returns>
+        internal static string GetFullName(INamespaceSymbol namespaceSymbol)
+        {
+            if (namespaceSymbol.ContainingNamespace != null &&
+                !namespaceSymbol.ContainingNamespace.IsGlobalNamespace)
+            {
+                return GetFullName(namespaceSymbol.ContainingNamespace) + "." + namespaceSymbol.Name;
+            }
+
+            return namespaceSymbol.Name;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/MarkReadonlyFieldsRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/MarkReadonlyFieldsRule.cs
@@ -1,0 +1,463 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.DotNet.CodeFormatting.Rules
+{
+    /// <summary>
+    /// Mark any fields that can provably be marked as readonly.
+    /// </summary>
+    [GlobalSemanticRule(GlobalSemanticRuleOrder.MarkReadonlyFieldsRule,
+        FormattingLevel = FormattingLevel.Agressive)]
+    internal sealed class MarkReadonlyFieldsRule : IGlobalSemanticFormattingRule
+    {
+        private readonly SemaphoreSlim _processUsagesLock = new SemaphoreSlim(1, 1);
+        private ConcurrentDictionary<IFieldSymbol, bool> _unwrittenWritableFields;
+
+        public bool SupportsLanguage(string languageName)
+        {
+            return languageName == LanguageNames.CSharp;
+        }
+
+        public async Task<Solution> ProcessAsync(
+            Document document,
+            SyntaxNode syntaxRoot,
+            CancellationToken cancellationToken)
+        {
+            if (_unwrittenWritableFields == null)
+            {
+                using (await SemaphoreLock.GetAsync(_processUsagesLock))
+                {
+                    // A global analysis must be run before we can do any actual processing, because a field might
+                    // be written in a different file than it is declared (even private ones may be split between
+                    // partial classes).
+
+                    // It's also quite expensive, which is why it's being done inside the lock, so
+                    // that the entire solution is not processed for each input file individually
+                    if (_unwrittenWritableFields == null)
+                    {
+                        List<Document> allDocuments =
+                            document.Project.Solution.Projects.SelectMany(p => p.Documents).ToList();
+                        HashSet<IFieldSymbol>[] fields = await Task.WhenAll(
+                            allDocuments
+                                .AsParallel()
+                                .Select(
+                                    doc => WritableFieldScanner.Scan(doc, cancellationToken)));
+
+                        var writableFields = new ConcurrentDictionary<IFieldSymbol, bool>(
+                            fields.SelectMany(s => s).Select(f => new KeyValuePair<IFieldSymbol, bool>(f, true)));
+
+                        await Task.WhenAll(
+                            allDocuments.AsParallel()
+                                .Select(
+                                    doc => WriteUsagesScanner.RemoveWrittenFields(
+                                        doc,
+                                        writableFields,
+                                        cancellationToken)));
+
+                        _unwrittenWritableFields = writableFields;
+                    }
+                }
+            }
+
+            if (_unwrittenWritableFields.Count == 0)
+            {
+                // If there are no unwritten writable fields, skip all the rewriting
+                return document.Project.Solution;
+            }
+
+            SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken);
+            var application = new ReadonlyRewriter(
+                _unwrittenWritableFields,
+                await document.GetSemanticModelAsync(cancellationToken));
+            return document.Project.Solution.WithDocumentSyntaxRoot(document.Id, application.Visit(root));
+        }
+
+        /// <summary>
+        /// This is the first walker, which looks for fields that are valid to transform to readonly.
+        /// It returns any private or internal fields that are not already marked readonly, and returns a hash set
+        /// of them. Internal fields are only considered if the "InternalsVisibleTo" is a reference to something
+        /// in the same solution, since it's possible to analyse the global usages of it. Otherwise there is an
+        /// assembly we don't have access to that can see that field, so we have to treat is as public.
+        /// </summary>
+        private sealed class WritableFieldScanner : CSharpSyntaxWalker
+        {
+            private static readonly HashSet<string> s_serializingFieldAttributes = new HashSet<string>
+            {
+                "System.ComponentModel.Composition.ImportAttribute",
+                "System.ComponentModel.Composition.ImportManyAttribute",
+            };
+
+            private readonly HashSet<IFieldSymbol> _fields = new HashSet<IFieldSymbol>();
+            private readonly ISymbol _internalsVisibleToAttribute;
+            private readonly SemanticModel _model;
+
+            private WritableFieldScanner(SemanticModel model)
+            {
+                _model = model;
+                _internalsVisibleToAttribute =
+                    model.Compilation.GetTypeByMetadataName(
+                        "System.Runtime.CompilerServices.InternalsVisibleToAttribute");
+            }
+
+            public static async Task<HashSet<IFieldSymbol>> Scan(
+                Document document,
+                CancellationToken cancellationToken)
+            {
+                var scanner = new WritableFieldScanner(
+                    await document.GetSemanticModelAsync(cancellationToken));
+                scanner.Visit(await document.GetSyntaxRootAsync(cancellationToken));
+                return scanner._fields;
+            }
+
+            public override void VisitFieldDeclaration(FieldDeclarationSyntax node)
+            {
+                var fieldSymbol = (IFieldSymbol)_model.GetDeclaredSymbol(node.Declaration.Variables[0]);
+
+                if (fieldSymbol.IsReadOnly || fieldSymbol.IsConst || fieldSymbol.IsExtern)
+                {
+                    return;
+                }
+
+                if (IsSymbolVisibleOutsideSolution(fieldSymbol, _internalsVisibleToAttribute))
+                {
+                    return;
+                }
+
+                if (IsFieldSerializableByAttributes(fieldSymbol))
+                {
+                    return;
+                }
+
+                _fields.Add(fieldSymbol);
+            }
+
+            private static bool IsSymbolVisibleOutsideSolution(ISymbol symbol, ISymbol internalsVisibleToAttribute)
+            {
+                Accessibility accessibility = symbol.DeclaredAccessibility;
+
+                if (accessibility == Accessibility.NotApplicable)
+                {
+                    if (symbol.Kind == SymbolKind.Field)
+                    {
+                        accessibility = Accessibility.Private;
+                    }
+                    else
+                    {
+                        accessibility = Accessibility.Internal;
+                    }
+                }
+
+                if (accessibility == Accessibility.Public || accessibility == Accessibility.Protected)
+                {
+                    if (symbol.ContainingType != null)
+                    {
+                        // a public symbol in a non-visible class isn't visible
+                        return IsSymbolVisibleOutsideSolution(symbol.ContainingType, internalsVisibleToAttribute);
+                    }
+
+                    // They are public, we are going to skip them.
+                    return true;
+                }
+
+                if (accessibility > Accessibility.Private)
+                {
+                    bool visibleOutsideSolution = IsVisibleOutsideSolution(
+                        symbol,
+                        internalsVisibleToAttribute);
+
+                    if (visibleOutsideSolution)
+                    {
+                        if (symbol.ContainingType != null)
+                        {
+                            // a visible symbol in a non-visible class isn't visible
+                            return IsSymbolVisibleOutsideSolution(
+                                symbol.ContainingType,
+                                internalsVisibleToAttribute);
+                        }
+
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            private static bool IsVisibleOutsideSolution(
+                ISymbol field,
+                ISymbol internalsVisibleToAttribute)
+            {
+                IAssemblySymbol assembly = field.ContainingAssembly;
+                return assembly.GetAttributes().Any(a => Equals(a.AttributeClass, internalsVisibleToAttribute));
+            }
+
+            private bool IsFieldSerializableByAttributes(IFieldSymbol field)
+            {
+                if (field.GetAttributes()
+                    .Any(attr => s_serializingFieldAttributes.Contains(NameHelper.GetFullName(attr.AttributeClass))))
+                {
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// This is the second walker. It checks all code for instances where one of the writable fields (as
+        /// calculated by <see cref="WritableFieldScanner" />) is written to, and removes it from the set.
+        /// Once the scan is complete, the set will not contain any fields written in the specified document.
+        /// </summary>
+        private sealed class WriteUsagesScanner : CSharpSyntaxWalker
+        {
+            private readonly SemanticModel _semanticModel;
+            private readonly ConcurrentDictionary<IFieldSymbol, bool> _writableFields;
+
+            private WriteUsagesScanner(
+                SemanticModel semanticModel,
+                ConcurrentDictionary<IFieldSymbol, bool> writableFields)
+            {
+                _semanticModel = semanticModel;
+                _writableFields = writableFields;
+            }
+
+            public override void VisitArgument(ArgumentSyntax node)
+            {
+                base.VisitArgument(node);
+
+                if (!node.RefOrOutKeyword.IsKind(SyntaxKind.None))
+                {
+                    CheckForFieldWrite(node.Expression);
+                }
+            }
+
+            public override void VisitAssignmentExpression(AssignmentExpressionSyntax node)
+            {
+                base.VisitAssignmentExpression(node);
+
+                CheckForFieldWrite(node.Left);
+            }
+
+            public override void VisitBinaryExpression(BinaryExpressionSyntax node)
+            {
+                base.VisitBinaryExpression(node);
+                switch (node.OperatorToken.Kind())
+                {
+                    case SyntaxKind.AddAssignmentExpression:
+                    case SyntaxKind.AndAssignmentExpression:
+                    case SyntaxKind.DivideAssignmentExpression:
+                    case SyntaxKind.ExclusiveOrAssignmentExpression:
+                    case SyntaxKind.LeftShiftAssignmentExpression:
+                    case SyntaxKind.ModuloAssignmentExpression:
+                    case SyntaxKind.MultiplyAssignmentExpression:
+                    case SyntaxKind.OrAssignmentExpression:
+                    case SyntaxKind.RightShiftAssignmentExpression:
+                    case SyntaxKind.SubtractAssignmentExpression:
+                        {
+                            CheckForFieldWrite(node.Left);
+                            break;
+                        }
+                }
+            }
+
+            public override void VisitIndexerDeclaration(IndexerDeclarationSyntax node)
+            {
+                base.VisitIndexerDeclaration(node);
+
+                if (node.Modifiers.Any(m => m.IsKind(SyntaxKind.ExternKeyword)))
+                {
+                    // This method body is unable to be analysed, so may contain writer instances
+                    CheckForRefParametersForExternMethod(node.ParameterList.Parameters);
+                }
+            }
+
+            public override void VisitInvocationExpression(InvocationExpressionSyntax node)
+            {
+                base.VisitInvocationExpression(node);
+
+                // A call to myStruct.myField.myMethod() will change if "myField" is marked
+                // readonly, since myMethod might modify it. So those need to be counted as writes
+
+                if (node.Expression.IsKind(SyntaxKind.SimpleMemberAccessExpression))
+                {
+                    var memberAccess = (MemberAccessExpressionSyntax)node.Expression;
+                    ISymbol symbol = _semanticModel.GetSymbolInfo(memberAccess.Expression).Symbol;
+                    if (symbol?.Kind == SymbolKind.Field)
+                    {
+                        var fieldSymbol = (IFieldSymbol)symbol;
+                        if (fieldSymbol.Type.TypeKind == TypeKind.Struct)
+                        {
+                            if (!IsImmutablePrimitiveType(fieldSymbol.Type))
+                            {
+                                MarkWriteInstance(fieldSymbol);
+                            }
+                        }
+                    }
+                }
+            }
+
+            public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
+            {
+                base.VisitMethodDeclaration(node);
+
+                if (node.Modifiers.Any(m => m.IsKind(SyntaxKind.ExternKeyword)))
+                {
+                    // This method body is unable to be analysed, so may contain writer instances
+                    CheckForRefParametersForExternMethod(node.ParameterList.Parameters);
+                }
+            }
+
+            private void CheckForRefParametersForExternMethod(IEnumerable<ParameterSyntax> parameters)
+            {
+                foreach (ParameterSyntax parameter in parameters)
+                {
+                    ITypeSymbol parameterType = _semanticModel.GetTypeInfo(parameter.Type).Type;
+                    if (parameterType == null)
+                    {
+                        continue;
+                    }
+
+                    bool canModify = true;
+                    if (parameterType.TypeKind == TypeKind.Struct)
+                    {
+                        canModify = parameter.Modifiers.Any(m => m.IsKind(SyntaxKind.RefKeyword));
+                    }
+
+                    if (canModify)
+                    {
+                        // This parameter might be used to modify one of the fields, since the
+                        // implmentation is hidden from this analysys. Assume all fields
+                        // of the type are written to
+
+                        foreach (IFieldSymbol field in parameterType.GetMembers().OfType<IFieldSymbol>())
+                        {
+                            MarkWriteInstance(field);
+                        }
+                    }
+                }
+            }
+
+            private void CheckForFieldWrite(ExpressionSyntax node)
+            {
+                var fieldSymbol = _semanticModel.GetSymbolInfo(node).Symbol as IFieldSymbol;
+
+                if (fieldSymbol != null)
+                {
+                    if (IsInsideOwnConstructor(node, fieldSymbol.ContainingType, fieldSymbol.IsStatic))
+                    {
+                        return;
+                    }
+
+                    MarkWriteInstance(fieldSymbol);
+                }
+            }
+
+            private bool IsImmutablePrimitiveType(ITypeSymbol type)
+            {
+                // All of the "special type" structs exposed are all immutable,
+                // so it's safe to assume all methods on them are non-mutating, and
+                // therefore safe to call on a readonly field
+                return type.SpecialType != SpecialType.None && type.TypeKind == TypeKind.Struct;
+            }
+
+            private bool IsInsideOwnConstructor(SyntaxNode node, ITypeSymbol type, bool isStatic)
+            {
+                while (node != null)
+                {
+                    switch (node.Kind())
+                    {
+                        case SyntaxKind.ConstructorDeclaration:
+                            {
+                                return _semanticModel.GetDeclaredSymbol(node).IsStatic == isStatic &&
+                                    IsInType(node.Parent, type);
+                            }
+                        case SyntaxKind.ParenthesizedLambdaExpression:
+                        case SyntaxKind.SimpleLambdaExpression:
+                        case SyntaxKind.AnonymousMethodExpression:
+                            return false;
+                    }
+
+                    node = node.Parent;
+                }
+                return false;
+            }
+
+            private bool IsInType(SyntaxNode node, ITypeSymbol containingType)
+            {
+                while (node != null)
+                {
+                    if (node.IsKind(SyntaxKind.ClassDeclaration) || node.IsKind(SyntaxKind.StructDeclaration))
+                    {
+                        return Equals(containingType, _semanticModel.GetDeclaredSymbol(node));
+                    }
+
+                    node = node.Parent;
+                }
+                return false;
+            }
+
+            private void MarkWriteInstance(IFieldSymbol fieldSymbol)
+            {
+                bool ignored;
+                _writableFields.TryRemove(fieldSymbol, out ignored);
+            }
+
+            public static async Task RemoveWrittenFields(
+                Document document,
+                ConcurrentDictionary<IFieldSymbol, bool> writableFields,
+                CancellationToken cancellationToken)
+            {
+                var scanner = new WriteUsagesScanner(
+                    await document.GetSemanticModelAsync(cancellationToken),
+                    writableFields);
+                scanner.Visit(await document.GetSyntaxRootAsync(cancellationToken));
+            }
+        }
+
+        /// <summary>
+        /// This is the actually rewriter, and should be run third, using the data gathered from the other two
+        /// (<see cref="WritableFieldScanner" /> and <see cref="WriteUsagesScanner" />).
+        /// Any field in the set is both writeable, but not actually written to, which means the "readonly"
+        /// modifier should be applied to it.
+        /// </summary>
+        private sealed class ReadonlyRewriter : CSharpSyntaxRewriter
+        {
+            private readonly SemanticModel _model;
+            private readonly ConcurrentDictionary<IFieldSymbol, bool> _unwrittenFields;
+
+            public ReadonlyRewriter(ConcurrentDictionary<IFieldSymbol, bool> unwrittenFields, SemanticModel model)
+            {
+                _model = model;
+                _unwrittenFields = unwrittenFields;
+            }
+
+            public override SyntaxNode VisitFieldDeclaration(FieldDeclarationSyntax node)
+            {
+                var fieldSymbol = (IFieldSymbol)_model.GetDeclaredSymbol(node.Declaration.Variables[0]);
+                bool ignored;
+                if (_unwrittenFields.TryRemove(fieldSymbol, out ignored))
+                {
+                    return
+                        node.WithModifiers(
+                            node.Modifiers.Add(
+                                SyntaxFactory.Token(
+                                    SyntaxFactory.TriviaList(),
+                                    SyntaxKind.ReadOnlyKeyword,
+                                    SyntaxFactory.TriviaList(
+                                        SyntaxFactory.SyntaxTrivia(SyntaxKind.WhitespaceTrivia, " ")))));
+                }
+
+                return node;
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/RuleOrder.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/RuleOrder.cs
@@ -33,5 +33,6 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
     internal static class GlobalSemanticRuleOrder
     {
         public const int PrivateFieldNamingRule = 1;
+        public const int MarkReadonlyFieldsRule = 2;
     }
 }

--- a/src/Microsoft.DotNet.CodeFormatting/SemaphoreLock.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/SemaphoreLock.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.CodeFormatting
+{
+    /// <summary>
+    /// IDisposable wrapper to use with SemaphoreSlim
+    /// </summary>
+    internal sealed class SemaphoreLock : IDisposable
+    {
+        private SemaphoreSlim _semaphore;
+
+        private SemaphoreLock(SemaphoreSlim semaphore)
+        {
+            _semaphore = semaphore;
+        }
+
+        public void Dispose()
+        {
+            Interlocked.Exchange(ref _semaphore, null)?.Release();
+        }
+
+        /// <summary>
+        /// Wait for the semaphore, and return a lock that, when diposed, will release it
+        /// </summary>
+        /// <param name="semaphore">Semphore to lock</param>
+        /// <returns>Lock that can be Disposed to release the semaphore</returns>
+        public static async Task<SemaphoreLock> GetAsync(SemaphoreSlim semaphore)
+        {
+            await semaphore.WaitAsync();
+            return new SemaphoreLock(semaphore);
+        }
+    }
+}


### PR DESCRIPTION
Add the readonly keyword to fields that are provably never written
to. Only mark private and internal fields, and the following
are considered "writing" to a field:

- Assignments (_field = 5)
- Compound assignments (_field += 5)
- ref/out calls (Method(ref _field))
- ref of parent to extern method. While not technically required
  the fields can possibly change (even when marked readonly)
- internal fields that are exposed via InternalsVisibleTo an
  assembly that is not in the input project

Fix #104