### PR TITLE
Verify Assert Argument Order

### DIFF
--- a/src/Microsoft.DotNet.CodeFormatting/Rules/RuleOrder.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/RuleOrder.cs
@@ -27,6 +27,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
         public const int ExplicitVisibilityRule = 2;
         public const int IsFormattedFormattingRule = 3;
         public const int RemoveExplicitThisRule = 4;
+        public const int AssertArgumentOrderRule = 5;
     }
 
     // Please keep these values sorted by number, not rule name.    

--- a/src/XUnitConverter.Tests/AssertArgumentOrderTest.cs
+++ b/src/XUnitConverter.Tests/AssertArgumentOrderTest.cs
@@ -1,0 +1,258 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+
+using Xunit;
+
+namespace XUnitConverter.Tests
+{
+    public class AssertArgumentOrderTest : ConverterTestBase
+    {
+        protected override XUnitConverter.ConverterBase CreateConverter()
+        {
+            return new XUnitConverter.AssertArgumentOrderConverter();
+        }
+
+        [Fact]
+        public async Task TestSwapInvertedEqual()
+        {
+            string source = @"
+public class Tests
+{
+    public void TestA()
+    {
+        int actual = 1;
+        Xunit.Assert.Equal(actual, 1);
+    }
+}
+";
+            string expected = @"
+public class Tests
+{
+    public void TestA()
+    {
+        int actual = 1;
+        Xunit.Assert.Equal(1, actual);
+    }
+}
+";
+
+            await Verify(source, expected);
+        }
+
+        [Fact]
+        public async Task TestSwapInvertedEqualEnum()
+        {
+            string source = @"
+public class Tests
+{
+    private enum E
+    {
+        A,
+        B,
+    }
+
+    public void TestA()
+    {
+        E actual = E.A;
+        Xunit.Assert.Equal(actual, E.A);
+    }
+}
+";
+            string expected = @"
+public class Tests
+{
+    private enum E
+    {
+        A,
+        B,
+    }
+
+    public void TestA()
+    {
+        E actual = E.A;
+        Xunit.Assert.Equal(E.A, actual);
+    }
+}
+";
+            await Verify(source, expected);
+        }
+
+        [Fact]
+        public async Task TestSwapInvertedEqualConstField()
+        {
+            string source = @"
+public class Tests
+{
+    private const int A;
+
+    public void TestA()
+    {
+        int actual = A;
+        Xunit.Assert.Equal(actual, A);
+    }
+}
+";
+            string expected = @"
+public class Tests
+{
+    private const int A;
+
+    public void TestA()
+    {
+        int actual = A;
+        Xunit.Assert.Equal(A, actual);
+    }
+}
+";
+            await Verify(source, expected);
+        }
+
+        [Fact]
+        public async Task TestSwapInvertedNotEqual()
+        {
+            string source = @"
+public class Tests
+{
+    public void TestA()
+    {
+        int actual = 1;
+        Xunit.Assert.NotEqual(actual, 1);
+    }
+}
+";
+            string expected = @"
+public class Tests
+{
+    public void TestA()
+    {
+        int actual = 1;
+        Xunit.Assert.NotEqual(1, actual);
+    }
+}
+";
+            await Verify(source, expected);
+        }
+
+        [Fact]
+        public async Task TestSwapInvertedEqualFromUsing()
+        {
+            string source = @"
+using Xunit;
+
+public class Tests
+{
+    public void TestA()
+    {
+        int actual = 1;
+        Assert.Equal(actual, 1);
+    }
+}
+";
+            string expected = @"
+using Xunit;
+
+public class Tests
+{
+    public void TestA()
+    {
+        int actual = 1;
+        Assert.Equal(1, actual);
+    }
+}
+";
+            await Verify(source, expected);
+        }
+
+        [Fact]
+        public async Task TestIgnoredCorrectEqual()
+        {
+            string text = @"
+public class Tests
+{
+    public void TestA()
+    {
+        int actual = 1;
+        Xunit.Assert.Equal(1, actual);
+    }
+}
+";
+            await Verify(text, text);
+        }
+
+        [Fact]
+        public async Task TestIgnoredDoubleConstEqual()
+        {
+            string text = @"
+public class Tests
+{
+    public void TestA()
+    {
+        Xunit.Assert.Equal(1, 2);
+    }
+}
+";
+            await Verify(text, text);
+        }
+
+        [Fact]
+        public async Task TestIgnoredDoubleVariableEqual()
+        {
+            string text = @"
+public class Tests
+{
+    public void TestA()
+    {
+        int actual = 1;
+        int expected = 1;
+        Xunit.Assert.Equal(actual, expected);
+    }
+}
+";
+            await Verify(text, text);
+        }
+
+        [Fact]
+        public async Task TestIgnoredCorrectNotEqual()
+        {
+            string text = @"
+public class Tests
+{
+    public void TestA()
+    {
+        int actual = 1;
+        Xunit.Assert.NotEqual(1, actual);
+    }
+}
+";
+            await Verify(text, text);
+        }
+
+        [Fact]
+        public async Task TestIgnoreOtherAssert()
+        {
+            string text = @"
+public class Assert
+{
+    public void Equal(int expected, int actual)
+    {
+    }
+}
+
+public class Tests
+{
+    public void TestA()
+    {
+        int actual = 1;
+        Assert.NotEqual(1, actual);
+    }
+}
+";
+            await Verify(text, text);
+        }
+    }
+}

--- a/src/XUnitConverter.Tests/XUnitConverter.Tests.csproj
+++ b/src/XUnitConverter.Tests/XUnitConverter.Tests.csproj
@@ -103,6 +103,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AssertArgumentOrderTest.cs" />
     <Compile Include="ConverterTestBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestAssertTrueOrFalseConverterTests.cs" />

--- a/src/XUnitConverter/AssertArgumentOrderConverter.cs
+++ b/src/XUnitConverter/AssertArgumentOrderConverter.cs
@@ -1,0 +1,140 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace XUnitConverter
+{
+    public sealed class AssertArgumentOrderConverter : ConverterBase
+    {
+        private class Rewriter : CSharpSyntaxRewriter
+        {
+            private readonly SemanticModel _model;
+
+            private static readonly HashSet<string> s_targetMethods =
+                new HashSet<string>(StringComparer.Ordinal)
+                {
+                    "Xunit.Assert.Equal",
+                    "Xunit.Assert.NotEqual",
+                };
+
+            private static readonly HashSet<string> s_actualParamterNames =
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    "actual",
+                };
+
+            private static readonly HashSet<string> s_expectedParamterNames =
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    "expected",
+                };
+
+            public Rewriter(SemanticModel model)
+            {
+                _model = model;
+            }
+
+            public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax node)
+            {
+                var symbol = _model.GetSymbolInfo(node.Expression).Symbol as IMethodSymbol;
+                if (symbol == null || !s_targetMethods.Contains(NameHelper.GetFullName(symbol)))
+                {
+                    return base.VisitInvocationExpression(node);
+                }
+
+                int actualIndex = IndexOfParameterWithName(symbol, s_actualParamterNames);
+                int expectedIndex = IndexOfParameterWithName(symbol, s_expectedParamterNames);
+
+                if (actualIndex == -1 || expectedIndex == -1)
+                {
+                    return base.VisitInvocationExpression(node);
+                }
+
+                var argumentList = (ArgumentListSyntax)Visit(node.ArgumentList);
+
+                if (!IsConstant(argumentList.Arguments[actualIndex].Expression) ||
+                    IsConstant(argumentList.Arguments[expectedIndex].Expression))
+                {
+                    // Since the arguments are already walked, use them and visit the expression
+                    return node.Update(
+                        (ExpressionSyntax)Visit(node.Expression),
+                        argumentList);
+                }
+
+                List<ArgumentSyntax> arguments = argumentList.Arguments.ToList();
+                ArgumentSyntax actualArgument = arguments[actualIndex];
+                ArgumentSyntax expectedArgument = arguments[expectedIndex];
+                arguments[actualIndex] = expectedArgument;
+                arguments[expectedIndex] = actualArgument;
+
+                return node.Update(
+                    (ExpressionSyntax)Visit(node.Expression),
+                    argumentList.WithArguments(SyntaxFactory.SeparatedList(arguments)));
+            }
+
+            private bool IsConstant(ExpressionSyntax expression)
+            {
+                switch (expression.Kind())
+                {
+                    case SyntaxKind.CharacterLiteralExpression:
+                    case SyntaxKind.FalseLiteralExpression:
+                    case SyntaxKind.NullLiteralExpression:
+                    case SyntaxKind.NumericLiteralExpression:
+                    case SyntaxKind.StringLiteralExpression:
+                    case SyntaxKind.TrueLiteralExpression:
+                        {
+                            return true;
+                        }
+
+                    case SyntaxKind.SimpleMemberAccessExpression:
+                    case SyntaxKind.IdentifierName:
+                        {
+                            ISymbol symbol = _model.GetSymbolInfo(expression).Symbol;
+
+                            if (symbol?.Kind == SymbolKind.Field)
+                            {
+                                return ((IFieldSymbol)symbol).IsConst;
+                            }
+
+                            break;
+                        }
+                }
+
+                return false;
+            }
+
+            private int IndexOfParameterWithName(IMethodSymbol symbol, HashSet<string> names)
+            {
+                for (int i = 0; i < symbol.Parameters.Length; i++)
+                {
+                    if (names.Contains(symbol.Parameters[i].Name))
+                    {
+                        return i;
+                    }
+                }
+
+                return -1;
+            }
+        }
+
+        protected override async Task<Solution> ProcessAsync(
+            Document document,
+            SyntaxNode syntaxRoot,
+            CancellationToken cancellationToken)
+        {
+            var rewriter = new Rewriter(await document.GetSemanticModelAsync(cancellationToken));
+            var newNode = rewriter.Visit(syntaxRoot);
+
+            return document.Project.Solution.WithDocumentSyntaxRoot(document.Id, newNode);
+        }
+    }
+}

--- a/src/XUnitConverter/NameHelper.cs
+++ b/src/XUnitConverter/NameHelper.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace XUnitConverter
+{
+    /// <summary>
+    /// Commonly used name functions
+    /// </summary>
+    internal static class NameHelper
+    {
+        /// <summary>
+        /// Get the full name of a symbol. So a field might look like
+        /// "OuterNamespace.Inner.ClassName.FieldName"
+        /// </summary>
+        /// <param name="symbol">symbol to get name of</param>
+        /// <returns>Full display name for a symbol</returns>
+        internal static string GetFullName(ISymbol symbol)
+        {
+            return GetFullName(symbol.ContainingType) + "." + symbol.Name;
+        }
+
+        /// <summary>
+        /// Get the full name of a type. i.e. "OuterNamespace.Inner.ClassName"
+        /// </summary>
+        /// <param name="type">type to get name of</param>
+        /// <returns>Full display name for a type</returns>
+        internal static string GetFullName(INamedTypeSymbol type)
+        {
+            if (type.ContainingType != null)
+            {
+                return GetFullName(type.ContainingType) + "+" + type.Name;
+            }
+
+            return GetFullName(type.ContainingNamespace) + "." + type.Name;
+        }
+
+        /// <summary>
+        /// Get the full name of a namespace. i.e. "OuterNamespace.Inner.ClassName"
+        /// </summary>
+        /// <param name="namespaceSymbol">namespace to get name of</param>
+        /// <returns>Full display name for a namespaceSymbol</returns>
+        internal static string GetFullName(INamespaceSymbol namespaceSymbol)
+        {
+            if (namespaceSymbol.ContainingNamespace != null &&
+                !namespaceSymbol.ContainingNamespace.IsGlobalNamespace)
+            {
+                return GetFullName(namespaceSymbol.ContainingNamespace) + "." + namespaceSymbol.Name;
+            }
+
+            return namespaceSymbol.Name;
+        }
+    }
+}

--- a/src/XUnitConverter/Program.cs
+++ b/src/XUnitConverter/Program.cs
@@ -35,7 +35,8 @@ namespace XUnitConverter
             var converters = new ConverterBase[]
                 {
                     new MSTestToXUnitConverter(),
-                    new TestAssertTrueOrFalseConverter()
+                    new TestAssertTrueOrFalseConverter(),
+                    new AssertArgumentOrderConverter(),
                 };
 
             foreach (var converter in converters)

--- a/src/XUnitConverter/XUnitConverter.csproj
+++ b/src/XUnitConverter/XUnitConverter.csproj
@@ -97,7 +97,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AssertArgumentOrderConverter.cs" />
     <Compile Include="ConverterBase.cs" />
+    <Compile Include="NameHelper.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestAssertTrueOrFalseConverter.cs" />


### PR DESCRIPTION
Test assert methods assume that the "actual" value is a variable
and the "expected" value is a constant for the most part. Inverting
these arguments causes misleading test failure messages that hinder
the ability to quickly diagnose test failures.

Detecting obvious mistakes (where "actual" is constant, and
"expected" is variable) can be done and the arguments swapped.

Fix #105