### PR TITLE
Add code formatting rule to add newlines at the end of code files

### DIFF
--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Microsoft.DotNet.CodeFormatting.Tests.csproj
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Microsoft.DotNet.CodeFormatting.Tests.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Rules\ExplicitVisibilityRuleTests.cs" />
     <Compile Include="Rules\HasNoIllegalHeadersFormattingRuleTests.cs" />
     <Compile Include="Rules\NewLineAboveRuleTests.cs" />
+    <Compile Include="Rules\NewLineAtEndOfFileRuleTests.cs" />
     <Compile Include="Rules\PrivateFieldNamingRuleTests.cs" />
     <Compile Include="Rules\NonAsciiCharactersAreEscapedInLiteralsRuleTests.cs" />
     <Compile Include="Rules\MarkReadonlyFieldTests.cs" />

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/CombinationTest.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/CombinationTest.cs
@@ -69,7 +69,8 @@ internal class C
     {
         N(_field);
     }
-}";
+}
+";
 
             Verify(text, expected, runFormatter: false);
         }
@@ -96,7 +97,8 @@ internal class C
     {
         _field = 42;
     }
-}";
+}
+";
 
             Verify(text, expected, runFormatter: false);
         }
@@ -119,7 +121,8 @@ internal class C
 #if DOG
     void M() { } 
 #endif 
-}";
+}
+";
 
             Verify(text, expected, runFormatter: false);
         }
@@ -145,7 +148,8 @@ internal class C
     {
     }
 #endif
-}";
+}
+";
 
             s_formattingEngine.PreprocessorConfigurations = ImmutableArray.CreateRange(new[] { new[] { "DOG" } });
             Verify(text, expected, runFormatter: false);
@@ -179,7 +183,8 @@ internal class C
     void M() {
 }
 #endif 
-}";
+}
+";
 
             Verify(text, expected, runFormatter: false);
         }
@@ -219,7 +224,8 @@ internal class C
     void M() {
 }
 #endif 
-}";
+}
+";
 
             s_formattingEngine.PreprocessorConfigurations = ImmutableArray.CreateRange(new[] { new[] { "TEST" } });
             Verify(text, expected, runFormatter: false);
@@ -262,7 +268,8 @@ internal class C
         {
         }
     }
-}";
+}
+";
 
             Verify(source, expected, runFormatter: false);
         }

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/NewLineAtEndOfFileRuleTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/NewLineAtEndOfFileRuleTests.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.DotNet.CodeFormatting.Tests
+{
+    public class NewLineAtEndOfFileRuleTests : SyntaxRuleTestBase
+    {
+        internal override ISyntaxFormattingRule Rule
+        {
+            get { return new Rules.NewLineAtEndOfFileRule(); }
+        }
+
+        [Fact]
+        public void SimpleClassWithoutNewLineAtEndOfFile()
+        {
+            var text = @"using System;
+public class TestClass
+{
+}";
+
+            var expected = @"using System;
+public class TestClass
+{
+}
+";
+
+            Verify(text, expected);
+        }
+
+        [Fact]
+        public void SimpleClassWithNewLineAtEndOfFile()
+        {
+            var text = @"using System;
+public class TestClass
+{
+}
+";
+
+            Verify(text, text);
+        }
+
+        [Fact]
+        public void CommentAtEndOfFile()
+        {
+            var text = @"using System;
+public class TestClass
+{
+}
+//  Hello World";
+
+            var expected = @"using System;
+public class TestClass
+{
+}
+//  Hello World
+";
+
+            Verify(text, expected);
+        }
+
+        [Fact]
+        public void IfDefAtEndOfFile()
+        {
+            var text = @"using System;
+public class TestClass
+{
+}
+#if TEST
+#endif";
+
+            var expected = @"using System;
+public class TestClass
+{
+}
+#if TEST
+#endif
+";
+
+            Verify(text, expected);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.CodeFormatting/Microsoft.DotNet.CodeFormatting.csproj
+++ b/src/Microsoft.DotNet.CodeFormatting/Microsoft.DotNet.CodeFormatting.csproj
@@ -88,6 +88,7 @@
     <Compile Include="NameHelper.cs" />
     <Compile Include="ResponseFileWorkspace.cs" />
     <Compile Include="Rules\MarkReadonlyFieldsRule.cs" />
+    <Compile Include="Rules\NewLineAtEndOfFileRule.cs" />
     <Compile Include="SemaphoreLock.cs" />
     <Compile Include="SyntaxUtil.cs" />
     <Compile Include="Filters\FilenameFilter.cs" />

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/NewLineAtEndOfFileRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/NewLineAtEndOfFileRule.cs
@@ -14,6 +14,17 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
         public SyntaxNode Process(SyntaxNode syntaxRoot, string languageName)
         {
             bool needsNewLine;
+            var endOfFileToken = syntaxRoot.GetLastToken(true, true, true, true);
+            if (!endOfFileToken.IsKind(SyntaxKind.EndOfFileToken))
+            {
+                throw new InvalidOperationException("Expected last token to be EndOfFileToken, was actually: " + endOfFileToken.Kind());
+            }
+
+            if (endOfFileToken.HasLeadingTrivia)
+            {
+                return AddNewLineToEndOfFileTokenLeadingTriviaIfNecessary(syntaxRoot, endOfFileToken);
+            }
+
             var lastToken = syntaxRoot.GetLastToken();
             if (!lastToken.HasTrailingTrivia)
             {
@@ -38,6 +49,21 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
                 var newLastToken = lastToken.WithTrailingTrivia(lastToken.TrailingTrivia.Concat(new[] { newLine }));
                 return syntaxRoot.ReplaceToken(lastToken, newLastToken);
             }
+            return syntaxRoot;
+        }
+
+        SyntaxNode AddNewLineToEndOfFileTokenLeadingTriviaIfNecessary(SyntaxNode syntaxRoot, SyntaxToken endofFileToken)
+        {
+            if (endofFileToken.LeadingTrivia.Last().IsKind(SyntaxKind.EndOfLineTrivia))
+            {
+                return syntaxRoot;
+            }
+
+            var newLine = SyntaxUtil.GetBestNewLineTriviaRecursive(endofFileToken.Parent);
+            var newLastToken = endofFileToken.WithTrailingTrivia(endofFileToken.TrailingTrivia.Concat(new[] { newLine }));
+            return syntaxRoot.ReplaceToken(endofFileToken, newLastToken);
+
+
             return syntaxRoot;
         }
     }

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/NewLineAtEndOfFileRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/NewLineAtEndOfFileRule.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.CodeFormatting.Rules
+{
+    [SyntaxRule(SyntaxRuleOrder.NewLineAtEndOfFileRule)]
+    internal sealed class NewLineAtEndOfFileRule : CSharpOnlyFormattingRule, ISyntaxFormattingRule
+    {
+        public SyntaxNode Process(SyntaxNode syntaxRoot, string languageName)
+        {
+            bool needsNewLine;
+            var lastToken = syntaxRoot.GetLastToken();
+            if (!lastToken.HasTrailingTrivia)
+            {
+                needsNewLine = true;
+            }
+            else
+            {
+                var lastTrivia = lastToken.TrailingTrivia.Last();
+                if (lastTrivia.IsKind(SyntaxKind.EndOfLineTrivia))
+                {
+                    needsNewLine = false;
+                }
+                else
+                {
+                    needsNewLine = true;
+                }
+            }
+
+            if (needsNewLine)
+            {
+                var newLine = SyntaxUtil.GetBestNewLineTriviaRecursive(lastToken.Parent);
+                var newLastToken = lastToken.WithTrailingTrivia(lastToken.TrailingTrivia.Concat(new[] { newLine }));
+                return syntaxRoot.ReplaceToken(lastToken, newLastToken);
+            }
+            return syntaxRoot;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/RuleOrder.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/RuleOrder.cs
@@ -16,6 +16,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
         public const int CopyrightHeaderRule = 2;
         public const int UsingLocationFormattingRule = 3;
         public const int NewLineAboveFormattingRule = 4;
+        public const int NewLineAtEndOfFileRule = 5;
         public const int BraceNewLineRule = 6;
         public const int NonAsciiChractersAreEscapedInLiterals = 7;
     }

--- a/src/Microsoft.DotNet.CodeFormatting/SyntaxUtil.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/SyntaxUtil.cs
@@ -30,6 +30,23 @@ namespace Microsoft.DotNet.CodeFormatting
             return defaultNewLineTrivia ?? SyntaxFactory.CarriageReturnLineFeed;
         }
 
+        internal static SyntaxTrivia GetBestNewLineTriviaRecursive(SyntaxNode node, SyntaxTrivia? defaultNewLineTrivia = null)
+        {
+            while(node != null)
+            {
+                SyntaxTrivia trivia;
+                if (TryGetExistingNewLine(node.GetLeadingTrivia(), out trivia) ||
+                    TryGetExistingNewLine(node.GetTrailingTrivia(), out trivia))
+                {
+                    return trivia;
+                }
+
+                node = node.Parent;
+            }
+
+            return defaultNewLineTrivia ?? SyntaxFactory.CarriageReturnLineFeed;
+        }
+
         internal static SyntaxTrivia GetBestNewLineTrivia(SyntaxToken token, SyntaxTrivia? defaultNewLineTrivia = null)
         {
             SyntaxTrivia trivia;


### PR DESCRIPTION
@stephentoub has [pointed out](https://github.com/dotnet/corefx/pull/1851#discussion_r31315254) that text files should end with a newline.  This PR adds a code formatting rule to do this for C# source code files.
