### PR TITLE
Enable / Disable rules at the command line 

### DIFF
--- a/src/CodeFormatter/CodeFormatter.csproj
+++ b/src/CodeFormatter/CodeFormatter.csproj
@@ -98,6 +98,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CommandLineParser.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/CodeFormatter/CommandLineParser.cs
+++ b/src/CodeFormatter/CommandLineParser.cs
@@ -1,0 +1,211 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.DotNet.CodeFormatting;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CodeFormatter
+{
+    public enum Operation
+    {
+        Format,
+        ListRules,
+    }
+
+    public sealed class CommandLineOptions
+    {
+        public static readonly CommandLineOptions ListRules = new CommandLineOptions(
+            Operation.ListRules,
+            ImmutableArray<string[]>.Empty,
+            ImmutableArray<string>.Empty,
+            ImmutableDictionary<string, bool>.Empty,
+            ImmutableArray<string>.Empty,
+            ImmutableArray<string>.Empty,
+            null,
+            allowTables: false,
+            verbose: false);
+
+        public readonly Operation Operation;
+        public readonly ImmutableArray<string[]> PreprocessorConfigurations;
+        public readonly ImmutableArray<string> CopyrightHeader;
+        public readonly ImmutableDictionary<string, bool> RuleMap;
+        public readonly ImmutableArray<string> FormatTargets;
+        public readonly ImmutableArray<string> FileNames;
+        public readonly string Language;
+        public readonly bool AllowTables;
+        public readonly bool Verbose;
+
+        public CommandLineOptions(
+            Operation operation,
+            ImmutableArray<string[]> preprocessorConfigurations,
+            ImmutableArray<string> copyrightHeader,
+            ImmutableDictionary<string, bool> ruleMap,
+            ImmutableArray<string> formatTargets,
+            ImmutableArray<string> fileNames,
+            string language,
+            bool allowTables,
+            bool verbose)
+        {
+            Operation = operation;
+            PreprocessorConfigurations = preprocessorConfigurations;
+            CopyrightHeader = copyrightHeader;
+            RuleMap = ruleMap;
+            FileNames = fileNames;
+            FormatTargets = formatTargets;
+            Language = language;
+            AllowTables = allowTables;
+            Verbose = verbose;
+        }
+    }
+
+    public static class CommandLineParser
+    {
+        private const string FileSwitch = "/file:";
+        private const string ConfigSwitch = "/c:";
+        private const string CopyrightSwitch = "/copyright:";
+        private const string LanguageSwitch = "/lang:";
+        private const string RuleEnabledSwitch1 = "/rule+:";
+        private const string RuleEnabledSwitch2 = "/rule:";
+        private const string RuleDisabledSwitch = "/rule-:";
+
+        public static void PrintUsage()
+        {
+            Console.WriteLine(
+@"CodeFormatter [/file:<filename>] [/lang:<language>] [/c:<config>[,<config>...]>]
+    [/copyright:<file> | /nocopyright] [/tables] [/nounicode] 
+    [/rule(+|-):rule1,rule2,...]  [/verbose]
+    <project, solution or response file>
+
+    /file        - Only apply changes to files with specified name
+    /lang        - Specifies the language to use when a responsefile is
+                   specified. i.e. 'C#', 'Visual Basic', ... (default: 'C#')
+    /c           - Additional preprocessor configurations the formatter
+                   should run under.
+    /copyright   - Specifies file containing copyright header.
+                   Use ConvertTests to convert MSTest tests to xUnit.
+    /nocopyright - Do not update the copyright message.
+    /tables      - Let tables opt out of formatting by defining
+                   DOTNET_FORMATTER
+    /nounicode   - Do not convert unicode strings to escape sequences
+    /rule(+|-)   - Enable (default) or disable the specified rule
+    /rules       - List the available rules
+    /verbose     - Verbose output
+");
+        }
+
+        public static bool TryParse(string[] args, out CommandLineOptions options)
+        {
+            if (args.Length < 1)
+            {
+                PrintUsage();
+                options = null;
+                return false;
+            }
+
+            var comparer = StringComparer.OrdinalIgnoreCase;
+            var formatTargets = new List<string>();
+            var fileNames = new List<string>();
+            var configBuilder = ImmutableArray.CreateBuilder<string[]>();
+            var copyrightHeader = FormattingDefaults.DefaultCopyrightHeader;
+            var ruleMap = ImmutableDictionary<string, bool>.Empty;
+            var language = LanguageNames.CSharp;
+            var allowTables = false;
+            var verbose = false;
+
+            for (int i = 1; i < args.Length; i++)
+            {
+                string arg = args[i];
+                if (arg.StartsWith(ConfigSwitch, StringComparison.OrdinalIgnoreCase))
+                {
+                    var all = arg.Substring(ConfigSwitch.Length);
+                    var configs = all.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                    configBuilder.Add(configs);
+                }
+                else if (arg.StartsWith(CopyrightSwitch, StringComparison.OrdinalIgnoreCase))
+                {
+                    var fileName = arg.Substring(CopyrightSwitch.Length);
+                    try
+                    {
+                        copyrightHeader = ImmutableArray.CreateRange(File.ReadAllLines(fileName));
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.Error.WriteLine("Could not read {0}", fileName);
+                        Console.Error.WriteLine(ex.Message);
+                        options = null;
+                        return false;
+                    }
+                }
+                else if (arg.StartsWith(LanguageSwitch, StringComparison.OrdinalIgnoreCase))
+                {
+                    language = arg.Substring(LanguageSwitch.Length);
+                }
+                else if (comparer.Equals(arg, "/nocopyright"))
+                {
+                    ruleMap = ruleMap.SetItem(FormattingDefaults.CopyrightRuleName, false);
+                }
+                else if (comparer.Equals(arg, "/nounicode"))
+                {
+                    ruleMap = ruleMap.SetItem(FormattingDefaults.UnicodeLiteralsRuleName, false);
+                }
+                else if (comparer.Equals(arg, "/verbose"))
+                {
+                    verbose = true;
+                }
+                else if (comparer.Equals(arg, FileSwitch))
+                {
+                    fileNames.Add(arg.Substring(FileSwitch.Length));
+                }
+                else if (comparer.Equals(arg, RuleEnabledSwitch1))
+                {
+                    UpdateRuleMap(ref ruleMap, arg.Substring(RuleEnabledSwitch1.Length), enabled: true);
+                }
+                else if (comparer.Equals(arg, RuleEnabledSwitch2))
+                {
+                    UpdateRuleMap(ref ruleMap, arg.Substring(RuleEnabledSwitch2.Length), enabled: true);
+                }
+                else if (comparer.Equals(arg, RuleDisabledSwitch))
+                {
+                    UpdateRuleMap(ref ruleMap, arg.Substring(RuleDisabledSwitch.Length), enabled: false);
+                }
+                else if (comparer.Equals(arg, "/tables"))
+                {
+                    allowTables = true;
+                }
+                else if (comparer.Equals(arg, "/rules"))
+                {
+                    options = CommandLineOptions.ListRules;
+                    return true;
+                }
+                else
+                {
+                    formatTargets.Add(arg);
+                }
+            }
+
+            options = new CommandLineOptions(
+                Operation.Format,
+                configBuilder.ToImmutableArray(),
+                copyrightHeader,
+                ruleMap,
+                formatTargets.ToImmutableArray(),
+                fileNames.ToImmutableArray(),
+                language,
+                allowTables,
+                verbose);
+            return true;
+        }
+
+        private static void UpdateRuleMap(ref ImmutableDictionary<string, bool> ruleMap, string data, bool enabled)
+        {
+            foreach (var current in data.Split(','))
+            {
+                ruleMap = ruleMap.SetItem(current, enabled);
+            }
+        }
+    }
+}

--- a/src/CodeFormatter/Program.cs
+++ b/src/CodeFormatter/Program.cs
@@ -44,12 +44,20 @@ namespace CodeFormatter
     /nounicode   - Do not convert unicode strings to escape sequences
     /simple      - Only run simple formatters (default)
     /agressive   - Run agressive form
+    /list        - List the available rules
     /verbose     - Verbose output
 ");
                 return -1;
             }
 
+            var comparer = StringComparer.OrdinalIgnoreCase;
             var projectOrSolutionPath = args[0];
+            if (comparer.Equals(projectOrSolutionPath, "/list"))
+            {
+                RunListRules();
+                return 0;
+            }
+
             if (!File.Exists(projectOrSolutionPath))
             {
                 Console.Error.WriteLine("Project, solution or response file {0} doesn't exist.", projectOrSolutionPath);
@@ -64,7 +72,6 @@ namespace CodeFormatter
             var convertUnicode = true;
             var allowTables = false;
             var verbose = false;
-            var comparer = StringComparer.OrdinalIgnoreCase;
             var formattingLevel = FormattingLevel.Simple;
 
             for (int i = 1; i < args.Length; i++)
@@ -164,6 +171,17 @@ namespace CodeFormatter
                     Console.WriteLine("- {0}", message);
 
                 return 1;
+            }
+        }
+
+        private static void RunListRules()
+        {
+            var rules = FormattingEngine.GetFormattingRules();
+            Console.WriteLine("{0,-20} {1}", "Name", "Description");
+            Console.WriteLine("==============================================");
+            foreach (var rule in rules)
+            {
+                Console.WriteLine("{0,-20} :{1}", rule.Name, rule.Description);
             }
         }
 

--- a/src/CodeFormatter/Program.cs
+++ b/src/CodeFormatter/Program.cs
@@ -69,10 +69,9 @@ namespace CodeFormatter
 
             var fileNamesBuilder = ImmutableArray.CreateBuilder<string>();
             var configBuilder = ImmutableArray.CreateBuilder<string[]>();
-            var copyrightHeader = FormattingConstants.DefaultCopyrightHeader;
+            var copyrightHeader = FormattingDefaults.DefaultCopyrightHeader;
             var ruleMap = ImmutableDictionary<string, bool>.Empty;
             var language = LanguageNames.CSharp;
-            var convertUnicode = true;
             var allowTables = false;
             var verbose = false;
 
@@ -111,11 +110,11 @@ namespace CodeFormatter
                 }
                 else if (comparer.Equals(arg, "/nocopyright"))
                 {
-                    copyrightHeader = ImmutableArray<string>.Empty;
+                    ruleMap = ruleMap.SetItem(FormattingDefaults.CopyrightRuleName, false);
                 }
                 else if (comparer.Equals(arg, "/nounicode"))
                 {
-                    convertUnicode = false;
+                    ruleMap = ruleMap.SetItem(FormattingDefaults.UnicodeLiteralsRuleName, false);
                 }
                 else if (comparer.Equals(arg, "/verbose"))
                 {
@@ -152,7 +151,6 @@ namespace CodeFormatter
                     ruleMap,
                     language,
                     allowTables,
-                    convertUnicode,
                     verbose);
         }
 
@@ -183,7 +181,6 @@ namespace CodeFormatter
             ImmutableDictionary<string, bool> ruleMap,
             string language,
             bool allowTables,
-            bool convertUnicode,
             bool verbose)
         {
             var cts = new CancellationTokenSource();
@@ -201,7 +198,6 @@ namespace CodeFormatter
                     ruleMap,
                     language,
                     allowTables,
-                    convertUnicode,
                     verbose,
                     ct).Wait(ct);
                 Console.WriteLine("Completed formatting.");
@@ -230,7 +226,6 @@ namespace CodeFormatter
             ImmutableDictionary<string, bool> ruleMap,
             string language,
             bool allowTables,
-            bool convertUnicode,
             bool verbose,
             CancellationToken cancellationToken)
         {
@@ -239,7 +234,6 @@ namespace CodeFormatter
             engine.FileNames = fileNames;
             engine.CopyrightHeader = copyrightHeader;
             engine.AllowTables = allowTables;
-            engine.ConvertUnicodeCharacters = convertUnicode;
             engine.Verbose = verbose;
 
             if (!SetRuleMap(engine, ruleMap))

--- a/src/CodeFormatter/Program.cs
+++ b/src/CodeFormatter/Program.cs
@@ -18,12 +18,15 @@ namespace CodeFormatter
     {
         private static int Main(string[] args)
         {
-            CommandLineOptions options;
-            if (!CommandLineParser.TryParse(args, out options))
+            var result = CommandLineParser.Parse(args);
+            if (result.IsError)
             {
+                Console.Error.WriteLine(result.Error);
+                CommandLineParser.PrintUsage();
                 return -1;
             }
 
+            var options = result.Options;
             int exitCode;
             switch (options.Operation)
             {

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/CommandLineParserTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/CommandLineParserTests.cs
@@ -1,0 +1,94 @@
+﻿using CodeFormatter;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.DotNet.CodeFormatting.Tests
+{
+    public class CommandLineParserTests
+    {
+        private CommandLineOptions Parse(params string[] args)
+        {
+            CommandLineOptions options;
+            Assert.True(CommandLineParser.TryParse(args, out options));
+            return options;
+        }
+
+        [Fact]
+        public void Rules()
+        {
+            var options = Parse("/rules");
+            Assert.Equal(Operation.ListRules, options.Operation);
+        }
+
+        [Fact]
+        public void Rules1()
+        {
+            var options = Parse("/rule:r1", "test.csproj");
+            Assert.True(options.RuleMap["r1"]);
+            Assert.Equal(new[] { "test.csproj" }, options.FormatTargets);
+        }
+
+        [Fact]
+        public void Rules2()
+        {
+            var options = Parse("/rule+:r1", "test.csproj");
+            Assert.True(options.RuleMap["r1"]);
+            Assert.Equal(new[] { "test.csproj" }, options.FormatTargets);
+        }
+
+        [Fact]
+        public void Rules3()
+        {
+            var options = Parse("/rule-:r1", "test.csproj");
+            Assert.False(options.RuleMap["r1"]);
+            Assert.Equal(new[] { "test.csproj" }, options.FormatTargets);
+        }
+
+        [Fact]
+        public void Rules4()
+        {
+            var options = Parse("/rule:r1,r2,r3", "test.csproj");
+            Assert.True(options.RuleMap["r1"]);
+            Assert.True(options.RuleMap["r2"]);
+            Assert.True(options.RuleMap["r3"]);
+            Assert.Equal(new[] { "test.csproj" }, options.FormatTargets);
+        }
+
+        [Fact]
+        public void Rules5()
+        {
+            var options = Parse("/rule-:r1,r2,r3", "test.csproj");
+            Assert.False(options.RuleMap["r1"]);
+            Assert.False(options.RuleMap["r2"]);
+            Assert.False(options.RuleMap["r3"]);
+            Assert.Equal(new[] { "test.csproj" }, options.FormatTargets);
+        }
+
+        [Fact]
+        public void NeedAtLeastOneTarget()
+        {
+            CommandLineOptions options;
+            Assert.False(CommandLineParser.TryParse(new[] { "/rule:foo" }, out options));
+        }
+
+        [Fact]
+        public void NoUnicode()
+        {
+            var options = Parse("/nounicode", "test.csproj");
+            Assert.False(options.RuleMap[FormattingDefaults.UnicodeLiteralsRuleName]);
+            Assert.Equal(new[] { "test.csproj" }, options.FormatTargets);
+        }
+
+        [Fact]
+        public void NoCopyright()
+        {
+            var options = Parse("/nocopyright", "test.csproj");
+            Assert.False(options.RuleMap[FormattingDefaults.CopyrightRuleName]);
+            Assert.Equal(new[] { "test.csproj" }, options.FormatTargets);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Microsoft.DotNet.CodeFormatting.Tests.csproj
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Microsoft.DotNet.CodeFormatting.Tests.csproj
@@ -105,6 +105,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CodeFormattingTestBase.cs" />
+    <Compile Include="CommandLineParserTests.cs" />
     <Compile Include="Rules\BracesRuleTests.cs" />
     <Compile Include="Rules\CombinationTest.cs" />
     <Compile Include="Rules\CopyrightHeaderRuleTests.cs" />
@@ -130,6 +131,10 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\CodeFormatter\CodeFormatter.csproj">
+      <Project>{b0e1a988-f762-459d-ad0d-56a3cf4fff3f}</Project>
+      <Name>CodeFormatter</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Microsoft.DotNet.CodeFormatting\Microsoft.DotNet.CodeFormatting.csproj">
       <Project>{d535641f-a2d7-481c-930d-96c02f052b95}</Project>
       <Name>Microsoft.DotNet.CodeFormatting</Name>

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/CombinationTest.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/CombinationTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.CodeFormatting.Tests
 
         static CombinationTest()
         {
-            s_formattingEngine = (FormattingEngineImplementation)FormattingEngine.Create(ImmutableArray<string>.Empty);
+            s_formattingEngine = (FormattingEngineImplementation)FormattingEngine.Create();
         }
 
         public CombinationTest()

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/CombinationTest.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/CombinationTest.cs
@@ -18,29 +18,25 @@ namespace Microsoft.DotNet.CodeFormatting.Tests
     /// </summary>
     public sealed class CombinationTest : CodeFormattingTestBase, IDisposable
     {
-        private static FormattingEngineImplementation s_formattingEngine;
-
-        static CombinationTest()
-        {
-            s_formattingEngine = (FormattingEngineImplementation)FormattingEngine.Create();
-        }
+        private FormattingEngineImplementation _formattingEngine;
 
         public CombinationTest()
         {
-            s_formattingEngine.CopyrightHeader = ImmutableArray.Create("// header");
-            s_formattingEngine.AllowTables = true;
-            s_formattingEngine.FormatLogger = new EmptyFormatLogger();
-            s_formattingEngine.PreprocessorConfigurations = ImmutableArray<string[]>.Empty;
+            _formattingEngine = (FormattingEngineImplementation)FormattingEngine.Create();
+            _formattingEngine.CopyrightHeader = ImmutableArray.Create("// header");
+            _formattingEngine.AllowTables = true;
+            _formattingEngine.FormatLogger = new EmptyFormatLogger();
+            _formattingEngine.PreprocessorConfigurations = ImmutableArray<string[]>.Empty;
         }
 
         public void Dispose()
         {
-            s_formattingEngine.AllowTables = false;
+            _formattingEngine.AllowTables = false;
         }
 
         protected override async Task<Document> RewriteDocumentAsync(Document document)
         {
-            var solution = await s_formattingEngine.FormatCoreAsync(
+            var solution = await _formattingEngine.FormatCoreAsync(
                 document.Project.Solution,
                 new[] { document.Id },
                 CancellationToken.None);
@@ -147,7 +143,7 @@ internal class C
 #endif
 }";
 
-            s_formattingEngine.PreprocessorConfigurations = ImmutableArray.CreateRange(new[] { new[] { "DOG" } });
+            _formattingEngine.PreprocessorConfigurations = ImmutableArray.CreateRange(new[] { new[] { "DOG" } });
             Verify(text, expected, runFormatter: false);
         }
 
@@ -221,7 +217,7 @@ internal class C
 #endif 
 }";
 
-            s_formattingEngine.PreprocessorConfigurations = ImmutableArray.CreateRange(new[] { new[] { "TEST" } });
+            _formattingEngine.PreprocessorConfigurations = ImmutableArray.CreateRange(new[] { new[] { "TEST" } });
             Verify(text, expected, runFormatter: false);
         }
 

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/NonAsciiCharactersAreEscapedInLiteralsRuleTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/NonAsciiCharactersAreEscapedInLiteralsRuleTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.CodeFormatting.Tests
     {
         internal override ISyntaxFormattingRule Rule
         {
-            get { return new Rules.NonAsciiCharactersAreEscapedInLiterals(new Options() { ConvertUnicodeCharacters = true }); }
+            get { return new Rules.NonAsciiCharactersAreEscapedInLiterals(); }
         }
 
         [Fact]

--- a/src/Microsoft.DotNet.CodeFormatting/FormattingDefaults.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/FormattingDefaults.cs
@@ -10,8 +10,11 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.CodeFormatting
 {
-    public static class FormattingConstants
+    public static class FormattingDefaults
     {
+        public const string UnicodeLiteralsRuleName = "UnicodeLiterals";
+        public const string CopyrightRuleName = "Copyright";
+
         private static readonly string[] s_defaultCopyrightHeader =
         {
             "// Copyright (c) Microsoft. All rights reserved.",
@@ -20,7 +23,7 @@ namespace Microsoft.DotNet.CodeFormatting
 
         public static readonly ImmutableArray<string> DefaultCopyrightHeader;
 
-        static FormattingConstants()
+        static FormattingDefaults()
         {
             DefaultCopyrightHeader = ImmutableArray.CreateRange(s_defaultCopyrightHeader);
         }

--- a/src/Microsoft.DotNet.CodeFormatting/FormattingEngine.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/FormattingEngine.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.CodeFormatting
 {
     public static class FormattingEngine
     {
-        public static IFormattingEngine Create(ImmutableArray<string> ruleTypes)
+        public static IFormattingEngine Create()
         {
             var container = CreateCompositionContainer();
             var engine = container.GetExportedValue<IFormattingEngine>();

--- a/src/Microsoft.DotNet.CodeFormatting/FormattingEngineImplementation.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/FormattingEngineImplementation.cs
@@ -73,12 +73,6 @@ namespace Microsoft.DotNet.CodeFormatting
             set { _verbose = value; }
         }
 
-        public bool ConvertUnicodeCharacters
-        {
-            get { return _options.ConvertUnicodeCharacters; }
-            set { _options.ConvertUnicodeCharacters = value; }
-        }
-
         public ImmutableArray<IRuleMetadata> AllRules
         {
             get

--- a/src/Microsoft.DotNet.CodeFormatting/IFormattingEngine.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/IFormattingEngine.cs
@@ -20,6 +20,6 @@ namespace Microsoft.DotNet.CodeFormatting
         bool Verbose { get; set; }
         FormattingLevel FormattingLevel { get; set; }
         Task FormatSolutionAsync(Solution solution, CancellationToken cancellationToken);
-        Task FormatProjectAsync(Project porject, CancellationToken cancellationToken);
+        Task FormatProjectAsync(Project project, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.DotNet.CodeFormatting/IFormattingEngine.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/IFormattingEngine.cs
@@ -15,10 +15,11 @@ namespace Microsoft.DotNet.CodeFormatting
         ImmutableArray<string> CopyrightHeader { get; set; }
         ImmutableArray<string[]> PreprocessorConfigurations { get; set; }
         ImmutableArray<string> FileNames { get; set; }
+        ImmutableArray<IRuleMetadata> AllRules { get; }
         bool AllowTables { get; set; }
         bool ConvertUnicodeCharacters { get; set; }
         bool Verbose { get; set; }
-        FormattingLevel FormattingLevel { get; set; }
+        void ToggleRuleEnabled(IRuleMetadata ruleMetaData, bool enabled);
         Task FormatSolutionAsync(Solution solution, CancellationToken cancellationToken);
         Task FormatProjectAsync(Project project, CancellationToken cancellationToken);
     }

--- a/src/Microsoft.DotNet.CodeFormatting/IFormattingEngine.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/IFormattingEngine.cs
@@ -17,7 +17,6 @@ namespace Microsoft.DotNet.CodeFormatting
         ImmutableArray<string> FileNames { get; set; }
         ImmutableArray<IRuleMetadata> AllRules { get; }
         bool AllowTables { get; set; }
-        bool ConvertUnicodeCharacters { get; set; }
         bool Verbose { get; set; }
         void ToggleRuleEnabled(IRuleMetadata ruleMetaData, bool enabled);
         Task FormatSolutionAsync(Solution solution, CancellationToken cancellationToken);

--- a/src/Microsoft.DotNet.CodeFormatting/IFormattingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/IFormattingRule.cs
@@ -9,12 +9,6 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.CodeFormatting
 {
-    public enum FormattingLevel
-    {
-        Simple = 0,
-        Agressive,
-    }
-
     /// <summary>
     /// Base formatting rule which helps establish which language the rule applies to.
     /// </summary>

--- a/src/Microsoft.DotNet.CodeFormatting/IRuleMetadata.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/IRuleMetadata.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.CodeFormatting
         [DefaultValue(int.MaxValue)]
         int Order { get; }
 
-        [DefaultValue(FormattingLevel.Simple)]
-        FormattingLevel FormattingLevel { get; }
+        [DefaultValue(true)]
+        bool DefaultRule { get; }
     }
 }

--- a/src/Microsoft.DotNet.CodeFormatting/IRuleMetadata.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/IRuleMetadata.cs
@@ -7,6 +7,12 @@ namespace Microsoft.DotNet.CodeFormatting
 {
     public interface IRuleMetadata
     {
+        [DefaultValue("")]
+        string Name { get; }
+
+        [DefaultValue("")]
+        string Description { get; }
+
         [DefaultValue(int.MaxValue)]
         int Order { get; }
 

--- a/src/Microsoft.DotNet.CodeFormatting/Microsoft.DotNet.CodeFormatting.csproj
+++ b/src/Microsoft.DotNet.CodeFormatting/Microsoft.DotNet.CodeFormatting.csproj
@@ -92,7 +92,7 @@
     <Compile Include="SyntaxUtil.cs" />
     <Compile Include="Filters\FilenameFilter.cs" />
     <Compile Include="Filters\UsableFileFilter.cs" />
-    <Compile Include="FormattingConstants.cs" />
+    <Compile Include="FormattingDefaults.cs" />
     <Compile Include="FormattingEngine.cs" />
     <Compile Include="FormattingEngineImplementation.cs" />
     <Compile Include="IFormatLogger.cs" />

--- a/src/Microsoft.DotNet.CodeFormatting/Options.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Options.cs
@@ -29,8 +29,6 @@ namespace Microsoft.DotNet.CodeFormatting
 
         internal bool ConvertUnicodeCharacters { get; set; }
 
-        internal FormattingLevel FormattingLevel { get; set; }
-
         [ImportingConstructor]
         internal Options()
         {

--- a/src/Microsoft.DotNet.CodeFormatting/Options.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Options.cs
@@ -27,16 +27,13 @@ namespace Microsoft.DotNet.CodeFormatting
 
         internal IFormatLogger FormatLogger { get; set; }
 
-        internal bool ConvertUnicodeCharacters { get; set; }
-
         [ImportingConstructor]
         internal Options()
         {
-            CopyrightHeader = FormattingConstants.DefaultCopyrightHeader;
+            CopyrightHeader = FormattingDefaults.DefaultCopyrightHeader;
             FileNames = ImmutableArray<string>.Empty;
             PreprocessorConfigurations = ImmutableArray<string[]>.Empty;
             FormatLogger = new ConsoleFormatLogger();
-            ConvertUnicodeCharacters = true;
         }
     }
 }

--- a/src/Microsoft.DotNet.CodeFormatting/RuleAttribute.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/RuleAttribute.cs
@@ -15,11 +15,19 @@ namespace Microsoft.DotNet.CodeFormatting
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     internal sealed class SyntaxRuleAttribute : ExportAttribute, IRuleMetadata
     {
-        public SyntaxRuleAttribute(int order)
+        public SyntaxRuleAttribute(string name, string description, int order)
             : base(typeof(ISyntaxFormattingRule))
         {
+            Name = name;
+            Description = description;
             Order = order;
         }
+
+        [DefaultValue("")]
+        public string Name { get; private set; }
+
+        [DefaultValue("")]
+        public string Description { get; private set; }
 
         [DefaultValue(int.MaxValue)]
         public int Order { get; private set; }
@@ -32,11 +40,19 @@ namespace Microsoft.DotNet.CodeFormatting
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     internal sealed class LocalSemanticRuleAttribute : ExportAttribute, IRuleMetadata
     {
-        public LocalSemanticRuleAttribute(int order)
+        public LocalSemanticRuleAttribute(string name, string description, int order)
             : base(typeof(ILocalSemanticFormattingRule))
         {
+            Name = name;
+            Description = description;
             Order = order;
         }
+
+        [DefaultValue("")]
+        public string Name { get; private set; }
+
+        [DefaultValue("")]
+        public string Description { get; private set; }
 
         [DefaultValue(int.MaxValue)]
         public int Order { get; private set; }
@@ -49,11 +65,19 @@ namespace Microsoft.DotNet.CodeFormatting
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     internal sealed class GlobalSemanticRuleAttribute : ExportAttribute, IRuleMetadata
     {
-        public GlobalSemanticRuleAttribute(int order)
+        public GlobalSemanticRuleAttribute(string name, string description, int order)
             : base(typeof(IGlobalSemanticFormattingRule))
         {
+            Name = name;
+            Description = description;
             Order = order;
         }
+
+        [DefaultValue("")]
+        public string Name { get; private set; }
+
+        [DefaultValue("")]
+        public string Description { get; private set; }
 
         [DefaultValue(int.MaxValue)]
         public int Order { get; private set; }

--- a/src/Microsoft.DotNet.CodeFormatting/RuleAttribute.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/RuleAttribute.cs
@@ -21,6 +21,7 @@ namespace Microsoft.DotNet.CodeFormatting
             Name = name;
             Description = description;
             Order = order;
+            DefaultRule = true;
         }
 
         [DefaultValue("")]
@@ -46,6 +47,7 @@ namespace Microsoft.DotNet.CodeFormatting
             Name = name;
             Description = description;
             Order = order;
+            DefaultRule = true;
         }
 
         [DefaultValue("")]
@@ -71,6 +73,7 @@ namespace Microsoft.DotNet.CodeFormatting
             Name = name;
             Description = description;
             Order = order;
+            DefaultRule = true;
         }
 
         [DefaultValue("")]

--- a/src/Microsoft.DotNet.CodeFormatting/RuleAttribute.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/RuleAttribute.cs
@@ -32,8 +32,8 @@ namespace Microsoft.DotNet.CodeFormatting
         [DefaultValue(int.MaxValue)]
         public int Order { get; private set; }
 
-        [DefaultValue(FormattingLevel.Simple)]
-        public FormattingLevel FormattingLevel { get; set; }
+        [DefaultValue(true)]
+        public bool DefaultRule { get; set; }
     }
 
     [MetadataAttribute]
@@ -57,8 +57,8 @@ namespace Microsoft.DotNet.CodeFormatting
         [DefaultValue(int.MaxValue)]
         public int Order { get; private set; }
 
-        [DefaultValue(FormattingLevel.Simple)]
-        public FormattingLevel FormattingLevel { get; set; }
+        [DefaultValue(true)]
+        public bool DefaultRule { get; set; }
     }
 
     [MetadataAttribute]
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.CodeFormatting
         [DefaultValue(int.MaxValue)]
         public int Order { get; private set; }
 
-        [DefaultValue(FormattingLevel.Simple)]
-        public FormattingLevel FormattingLevel { get; set; }
+        [DefaultValue(true)]
+        public bool DefaultRule { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/BraceNewLineRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/BraceNewLineRule.cs
@@ -13,9 +13,12 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {
-    [SyntaxRule(SyntaxRuleOrder.BraceNewLineRule)]
+    [SyntaxRule(BraceNewLineRule.Name, BraceNewLineRule.Description, SyntaxRuleOrder.BraceNewLineRule)]
     internal sealed class BraceNewLineRule : CSharpOnlyFormattingRule, ISyntaxFormattingRule
     {
+        internal const string Name = "BraceNewLine";
+        internal const string Description = "Ensure all braces occur on a new line";
+
         private enum NewLineKind
         {
             WhitespaceAndNewLine,

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.cs
@@ -12,9 +12,12 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {
-    [SyntaxRule(SyntaxRuleOrder.CopyrightHeaderRule)]
+    [SyntaxRule(CopyrightHeaderRule.Name, CopyrightHeaderRule.Description, SyntaxRuleOrder.CopyrightHeaderRule)]
     internal sealed partial class CopyrightHeaderRule : SyntaxFormattingRule, ISyntaxFormattingRule
     {
+        internal const string Name = "Copyright";
+        internal const string Description = "Insert the copyright header into every file";
+
         private abstract class CommonRule
         {
             /// <summary>

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
     [SyntaxRule(CopyrightHeaderRule.Name, CopyrightHeaderRule.Description, SyntaxRuleOrder.CopyrightHeaderRule)]
     internal sealed partial class CopyrightHeaderRule : SyntaxFormattingRule, ISyntaxFormattingRule
     {
-        internal const string Name = "Copyright";
+        internal const string Name = FormattingDefaults.CopyrightRuleName;
         internal const string Description = "Insert the copyright header into every file";
 
         private abstract class CommonRule

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/ExplicitThisRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/ExplicitThisRule.cs
@@ -14,9 +14,12 @@ using Microsoft.CodeAnalysis.Simplification;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {
-    [LocalSemanticRule(LocalSemanticRuleOrder.RemoveExplicitThisRule)]
+    [LocalSemanticRule(ExplicitThisRule.Name, ExplicitThisRule.Description, LocalSemanticRuleOrder.RemoveExplicitThisRule)]
     internal sealed class ExplicitThisRule : CSharpOnlyFormattingRule, ILocalSemanticFormattingRule
     {
+        internal const string Name = "ExplicitThis";
+        internal const string Description = "Remove explicit this/Me prefixes on expressions except where necessary";
+
         private sealed class ExplicitThisRewriter : CSharpSyntaxRewriter
         {
             private readonly Document _document;

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/ExplicitVisibilityRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/ExplicitVisibilityRule.cs
@@ -14,9 +14,12 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {
-    [LocalSemanticRule(LocalSemanticRuleOrder.ExplicitVisibilityRule)]
+    [LocalSemanticRule(ExplicitVisibilityRule.Name, ExplicitVisibilityRule.Description, LocalSemanticRuleOrder.ExplicitVisibilityRule)]
     internal sealed partial class ExplicitVisibilityRule : ILocalSemanticFormattingRule
     {
+        internal const string Name = "ExplicitVisibility";
+        internal const string Description = "Ensure all members have an explicit visibility modifier";
+
         public bool SupportsLanguage(string languageName)
         {
             return

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/FormatDocumentFormattingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/FormatDocumentFormattingRule.cs
@@ -17,9 +17,11 @@ using Microsoft.CodeAnalysis.VisualBasic;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {
-    [LocalSemanticRule(LocalSemanticRuleOrder.IsFormattedFormattingRule)]
+    [LocalSemanticRule(FormatDocumentFormattingRule.Name, FormatDocumentFormattingRule.Description, LocalSemanticRuleOrder.IsFormattedFormattingRule)]
     internal sealed class FormatDocumentFormattingRule : ILocalSemanticFormattingRule
     {
+        internal const string Name = "FormatDocument";
+        internal const string Description = "Run the language specific formatter on every document";
         private readonly Options _options;
 
         [ImportingConstructor]

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/HasNoCustomCopyrightHeaderFormattingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/HasNoCustomCopyrightHeaderFormattingRule.cs
@@ -15,9 +15,12 @@ using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {
-    [SyntaxRule(SyntaxRuleOrder.HasNoCustomCopyrightHeaderFormattingRule)]
+    [SyntaxRule(HasNoCustomCopyrightHeaderFormattingRule.Name, HasNoCustomCopyrightHeaderFormattingRule.Description, SyntaxRuleOrder.HasNoCustomCopyrightHeaderFormattingRule)]
     internal sealed class HasNoCustomCopyrightHeaderFormattingRule : CSharpOnlyFormattingRule, ISyntaxFormattingRule
     {
+        internal const string Name = "CustomCopyright";
+        internal const string Description = "Remove any custom copyright header from the file";
+
         private static string RulerMarker { get; set; }
         private static string StartMarker { get; set; }
         private static string EndMarker { get; set; }

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/HasNoIllegalHeadersFormattingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/HasNoIllegalHeadersFormattingRule.cs
@@ -15,9 +15,12 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {
-    [LocalSemanticRule(LocalSemanticRuleOrder.HasNoIllegalHeadersFormattingRule)]
+    [LocalSemanticRule(HasNoIllegalHeadersFormattingRule.Name, HasNoIllegalHeadersFormattingRule.Description, LocalSemanticRuleOrder.HasNoIllegalHeadersFormattingRule)]
     internal sealed class HasNoIllegalHeadersFormattingRule : CSharpOnlyFormattingRule, ILocalSemanticFormattingRule
     {
+        internal const string Name = "IllegalHeaders";
+        internal const string Description = "Remove illegal headers from files";
+
         // We are going to replace this header with the actual filename of the document being processed
         private const string FileNameIllegalHeader = "<<<filename>>>";
 

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/MarkReadonlyFieldsRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/MarkReadonlyFieldsRule.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
     /// <summary>
     /// Mark any fields that can provably be marked as readonly.
     /// </summary>
-    [GlobalSemanticRule(MarkReadonlyFieldsRule.Name, MarkReadonlyFieldsRule.Description, GlobalSemanticRuleOrder.MarkReadonlyFieldsRule, FormattingLevel = FormattingLevel.Agressive)]
+    [GlobalSemanticRule(MarkReadonlyFieldsRule.Name, MarkReadonlyFieldsRule.Description, GlobalSemanticRuleOrder.MarkReadonlyFieldsRule, DefaultRule = false)]
     internal sealed class MarkReadonlyFieldsRule : IGlobalSemanticFormattingRule
     {
         internal const string Name = "ReadonlyFields";

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/MarkReadonlyFieldsRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/MarkReadonlyFieldsRule.cs
@@ -16,10 +16,12 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
     /// <summary>
     /// Mark any fields that can provably be marked as readonly.
     /// </summary>
-    [GlobalSemanticRule(GlobalSemanticRuleOrder.MarkReadonlyFieldsRule,
-        FormattingLevel = FormattingLevel.Agressive)]
+    [GlobalSemanticRule(MarkReadonlyFieldsRule.Name, MarkReadonlyFieldsRule.Description, GlobalSemanticRuleOrder.MarkReadonlyFieldsRule, FormattingLevel = FormattingLevel.Agressive)]
     internal sealed class MarkReadonlyFieldsRule : IGlobalSemanticFormattingRule
     {
+        internal const string Name = "ReadonlyFields";
+        internal const string Description = "Mark fields which can be readonly as readonly";
+
         private readonly SemaphoreSlim _processUsagesLock = new SemaphoreSlim(1, 1);
         private ConcurrentDictionary<IFieldSymbol, bool> _unwrittenWritableFields;
 

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/NewLineAboveRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/NewLineAboveRule.cs
@@ -18,9 +18,12 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
     /// <summary>
     /// Ensure there is a blank line above the first using and namespace in the file. 
     /// </summary>
-    [SyntaxRule(SyntaxRuleOrder.NewLineAboveFormattingRule)]
+    [SyntaxRule(NewLineAboveRule.Name, NewLineAboveRule.Description, SyntaxRuleOrder.NewLineAboveFormattingRule)]
     internal sealed class NewLineAboveRule : CSharpOnlyFormattingRule, ISyntaxFormattingRule
     {
+        internal const string Name = "NewLineAbove";
+        internal const string Description = "Ensure there is a new line above the first namespace and using in the file";
+
         public SyntaxNode Process(SyntaxNode syntaxRoot, string languageName)
         {
             syntaxRoot = ProcessUsing(syntaxRoot);

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/NonAsciiCharactersAreEscapedInLiteralsRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/NonAsciiCharactersAreEscapedInLiteralsRule.cs
@@ -17,24 +17,11 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
     [SyntaxRule(NonAsciiCharactersAreEscapedInLiterals.Name, NonAsciiCharactersAreEscapedInLiterals.Description, SyntaxRuleOrder.NonAsciiChractersAreEscapedInLiterals)]
     internal sealed class NonAsciiCharactersAreEscapedInLiterals : CSharpOnlyFormattingRule, ISyntaxFormattingRule
     {
-        internal const string Name = "UnicodeLiterals";
+        internal const string Name = FormattingDefaults.UnicodeLiteralsRuleName;
         internal const string Description = "Use unicode escape sequence instead of unicode literals";
-
-        private readonly Options _options;
-
-        [ImportingConstructor]
-        internal NonAsciiCharactersAreEscapedInLiterals(Options options)
-        {
-            _options = options;
-        }
 
         public SyntaxNode Process(SyntaxNode root, string languageName)
         {
-            if (!_options.ConvertUnicodeCharacters)
-            {
-                return root;
-            }
-
             return UnicodeCharacterEscapingSyntaxRewriter.Rewriter.Visit(root);
         }
 

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/NonAsciiCharactersAreEscapedInLiteralsRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/NonAsciiCharactersAreEscapedInLiteralsRule.cs
@@ -14,9 +14,12 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {
-    [SyntaxRule(SyntaxRuleOrder.NonAsciiChractersAreEscapedInLiterals)]
+    [SyntaxRule(NonAsciiCharactersAreEscapedInLiterals.Name, NonAsciiCharactersAreEscapedInLiterals.Description, SyntaxRuleOrder.NonAsciiChractersAreEscapedInLiterals)]
     internal sealed class NonAsciiCharactersAreEscapedInLiterals : CSharpOnlyFormattingRule, ISyntaxFormattingRule
     {
+        internal const string Name = "UnicodeLiterals";
+        internal const string Description = "Use unicode escape sequence instead of unicode literals";
+
         private readonly Options _options;
 
         [ImportingConstructor]

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/PrivateFieldNamingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/PrivateFieldNamingRule.cs
@@ -15,9 +15,12 @@ using Microsoft.CodeAnalysis.Rename;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {
-    [GlobalSemanticRule(GlobalSemanticRuleOrder.PrivateFieldNamingRule)]
+    [GlobalSemanticRule(PrivateFieldNamingRule.Name, PrivateFieldNamingRule.Description, GlobalSemanticRuleOrder.PrivateFieldNamingRule)]
     internal partial class PrivateFieldNamingRule : IGlobalSemanticFormattingRule
     {
+        internal const string Name = "FieldNames";
+        internal const string Description = "Prefix private fields with _ and statics with s_";
+
         #region CommonRule
 
         private abstract class CommonRule

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/UsingLocationRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/UsingLocationRule.cs
@@ -16,9 +16,12 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
     /// <summary>
     /// This will ensure that using directives are placed outside of the namespace.
     /// </summary>
-    [SyntaxRule(SyntaxRuleOrder.UsingLocationFormattingRule)]
+    [SyntaxRule(UsingLocationRule.Name, UsingLocationRule.Description, SyntaxRuleOrder.UsingLocationFormattingRule)]
     internal sealed class UsingLocationRule : CSharpOnlyFormattingRule, ISyntaxFormattingRule
     {
+        internal const string Name = "UsingLocation";
+        internal const string Description = "Place using directives outside namespace declarations";
+
         public SyntaxNode Process(SyntaxNode syntaxNode, string languageName)
         {
             var root = syntaxNode as CompilationUnitSyntax;


### PR DESCRIPTION
This change adds the ability to enable / disable rules at the command line using the `/rule+:` and `/rule-:` switch.  

closes #124 