### PR TITLE
build.cmd should always check for NuGet package updates

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -32,9 +32,7 @@ IF NOT EXIST %LocalAppData%\NuGet md %LocalAppData%\NuGet
 @powershell -NoProfile -ExecutionPolicy unrestricted -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://www.nuget.org/nuget.exe' -OutFile '%CACHED_NUGET%'"
 
 :restore
-IF EXIST "%~dp0src\packages" goto build
+IF NOT EXIST src\packages md src\packages
 %CACHED_NUGET% restore %SOLUTION_PATH%
-
-:build
 
 %BUILD_TOOLS_PATH% %SOLUTION_PATH% /p:OutDir="%~dp0bin" /nologo /m /v:m /flp:verbosity=normal %*


### PR DESCRIPTION
build.cmd was skipping the NuGet restore command if the
src\packages directory existed at all, regardless of what
was in it. As a result, the command line build would fail
whenever we updated a package (as, for example, I did
yesterday in updating to Roslyn 1.0.0-rc3).

Modify build.cmd to restore packages unconditionally. The
fraction of a second it takes to discover that all packages
are up to date is not significant.

@srivatsn @jaredpar