### PR TITLE
Using the /nocopyright switch produces 2 blank lines on the top of every files

### DIFF
--- a/src/Microsoft.DotNet.CodeFormatting/Rules/NewLineAboveRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/NewLineAboveRule.cs
@@ -36,6 +36,12 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
                 return syntaxRoot;
             }
 
+            bool usingIsFirstInSource = syntaxRoot.DescendantNodes().FirstOrDefault() == firstUsing;
+            if (usingIsFirstInSource)
+            {
+                return syntaxRoot;
+            }
+
             return ProcessCore(syntaxRoot, firstUsing);
         }
 
@@ -43,6 +49,12 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
         {
             var firstNamespace = syntaxRoot.DescendantNodesAndSelf().OfType<NamespaceDeclarationSyntax>().FirstOrDefault();
             if (firstNamespace == null)
+            {
+                return syntaxRoot;
+            }
+
+            bool namespaceIsFirstInSource = syntaxRoot.DescendantNodes().FirstOrDefault() == firstNamespace;
+            if (namespaceIsFirstInSource)
             {
                 return syntaxRoot;
             }


### PR DESCRIPTION
Fixes #102 
