### PR TITLE
Prepare for analyzer/fixer based formatting operations

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -32,9 +32,7 @@ IF NOT EXIST %LocalAppData%\NuGet md %LocalAppData%\NuGet
 @powershell -NoProfile -ExecutionPolicy unrestricted -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://www.nuget.org/nuget.exe' -OutFile '%CACHED_NUGET%'"
 
 :restore
-IF EXIST "%~dp0src\packages" goto build
+IF NOT EXIST src\packages md src\packages
 %CACHED_NUGET% restore %SOLUTION_PATH%
-
-:build
 
 %BUILD_TOOLS_PATH% %SOLUTION_PATH% /p:OutDir="%~dp0bin" /nologo /m /v:m /flp:verbosity=normal %*

--- a/src/CodeFormatter/CodeFormatter.csproj
+++ b/src/CodeFormatter/CodeFormatter.csproj
@@ -45,7 +45,6 @@
       <HintPath>..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/CodeFormattingTestBase.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/CodeFormattingTestBase.cs
@@ -52,24 +52,7 @@ namespace Microsoft.DotNet.CodeFormatting.Tests
             return solution;
         }
 
-        private async Task<Solution> Format(Solution solution, bool runFormatter)
-        {
-            var documentIds = solution.Projects.SelectMany(p => p.DocumentIds);
-
-            foreach (var id in documentIds)
-            {
-                var document = solution.GetDocument(id);
-                document = await RewriteDocumentAsync(document);
-                if (runFormatter)
-                {
-                    document = await Formatter.FormatAsync(document);
-                }
-
-                solution = document.Project.Solution;
-            }
-
-            return solution;
-        }
+        protected abstract Task<Solution> Format(Solution solution, bool runFormatter);
 
         private void AssertSolutionEqual(Solution expectedSolution, Solution actualSolution)
         {
@@ -87,8 +70,6 @@ namespace Microsoft.DotNet.CodeFormatting.Tests
                 }
             }
         }
-
-        protected abstract Task<Document> RewriteDocumentAsync(Document document);
 
         protected void Verify(string[] sources, string[] expected, bool runFormatter, string languageName)
         {
@@ -110,7 +91,26 @@ namespace Microsoft.DotNet.CodeFormatting.Tests
 
     public abstract class RuleTestBase : CodeFormattingTestBase
     {
+        protected override async Task<Solution> Format(Solution solution, bool runFormatter)
+        {
+            var documentIds = solution.Projects.SelectMany(p => p.DocumentIds);
 
+            foreach (var id in documentIds)
+            {
+                var document = solution.GetDocument(id);
+                document = await RewriteDocumentAsync(document);
+                if (runFormatter)
+                {
+                    document = await Formatter.FormatAsync(document);
+                }
+
+                solution = document.Project.Solution;
+            }
+
+            return solution;
+        }
+
+        protected abstract Task<Document> RewriteDocumentAsync(Document document);
     }
 
     public abstract class SyntaxRuleTestBase : RuleTestBase

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/CodeFormattingTestBase.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/CodeFormattingTestBase.cs
@@ -1,16 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.DotNet.CodeFormatting;
 using Xunit;
 
 namespace Microsoft.DotNet.CodeFormatting.Tests
@@ -111,7 +108,12 @@ namespace Microsoft.DotNet.CodeFormatting.Tests
         }
     }
 
-    public abstract class SyntaxRuleTestBase : CodeFormattingTestBase
+    public abstract class RuleTestBase : CodeFormattingTestBase
+    {
+
+    }
+
+    public abstract class SyntaxRuleTestBase : RuleTestBase
     {
         internal abstract ISyntaxFormattingRule Rule
         {
@@ -126,7 +128,7 @@ namespace Microsoft.DotNet.CodeFormatting.Tests
         }
     }
 
-    public abstract class LocalSemanticRuleTestBase : CodeFormattingTestBase
+    public abstract class LocalSemanticRuleTestBase : RuleTestBase
     {
         internal abstract ILocalSemanticFormattingRule Rule
         {
@@ -141,7 +143,7 @@ namespace Microsoft.DotNet.CodeFormatting.Tests
         }
     }
 
-    public abstract class GlobalSemanticRuleTestBase : CodeFormattingTestBase
+    public abstract class GlobalSemanticRuleTestBase : RuleTestBase
     {
         internal abstract IGlobalSemanticFormattingRule Rule
         {

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Microsoft.DotNet.CodeFormatting.Tests.csproj
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Microsoft.DotNet.CodeFormatting.Tests.csproj
@@ -48,7 +48,6 @@
       <HintPath>..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/CombinationTest.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/CombinationTest.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -17,7 +14,7 @@ namespace Microsoft.DotNet.CodeFormatting.Tests
     /// <summary>
     /// A test which runs all rules on a given piece of code 
     /// </summary>
-    public sealed class CombinationTest : CodeFormattingTestBase
+    public sealed class CombinationTest : RuleTestBase
     {
         private FormattingEngineImplementation _formattingEngine;
 

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/MarkReadonlyFieldTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/MarkReadonlyFieldTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.ComponentModel.Composition;
+using System.Composition;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;
@@ -268,7 +268,7 @@ class C
         public void TestIgnoredImportedField()
         {
             string text = @"
-using System.ComponentModel.Composition;
+using System.Composition;
 
 public interface ITest
 {

--- a/src/Microsoft.DotNet.CodeFormatting/Filters/FilenameFilter.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Filters/FilenameFilter.cs
@@ -2,19 +2,16 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Composition;
 using System.IO;
 
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.CodeFormatting.Filters
 {
-    [Export(typeof(IFormattingFilter))]
     internal sealed class FilenameFilter : IFormattingFilter
     {
         private readonly Options _options;
 
-        [ImportingConstructor]
         public FilenameFilter(Options options)
         {
             _options = options;

--- a/src/Microsoft.DotNet.CodeFormatting/Filters/FilenameFilter.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Filters/FilenameFilter.cs
@@ -2,12 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.ComponentModel.Composition;
+using System.Composition;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.CodeFormatting.Filters

--- a/src/Microsoft.DotNet.CodeFormatting/Filters/IgnoreGeneratedFilesFilter.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Filters/IgnoreGeneratedFilesFilter.cs
@@ -2,8 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.ComponentModel.Composition;
-using System.Threading.Tasks;
+using System.Composition;
 
 using Microsoft.CodeAnalysis;
 

--- a/src/Microsoft.DotNet.CodeFormatting/Filters/IgnoreGeneratedFilesFilter.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Filters/IgnoreGeneratedFilesFilter.cs
@@ -2,13 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Composition;
 
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.CodeFormatting.Filters
 {
-    [Export(typeof(IFormattingFilter))]
     internal sealed class IgnoreGeneratedFilesFilter : IFormattingFilter
     {
         public bool ShouldBeProcessed(Document document)

--- a/src/Microsoft.DotNet.CodeFormatting/Filters/UsableFileFilter.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Filters/UsableFileFilter.cs
@@ -1,14 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.Composition;
+using System.Composition;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.CodeFormatting.Filters
 {
@@ -18,7 +14,7 @@ namespace Microsoft.DotNet.CodeFormatting.Filters
         private readonly Options _options;
 
         [ImportingConstructor]
-        internal UsableFileFilter(Options options)
+        public UsableFileFilter(Options options)
         {
             _options = options;
         }

--- a/src/Microsoft.DotNet.CodeFormatting/Filters/UsableFileFilter.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Filters/UsableFileFilter.cs
@@ -1,19 +1,16 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Composition;
 using System.IO;
 
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.CodeFormatting.Filters
 {
-    [Export(typeof(IFormattingFilter))]
     internal sealed class UsableFileFilter : IFormattingFilter
     {
         private readonly Options _options;
 
-        [ImportingConstructor]
         public UsableFileFilter(Options options)
         {
             _options = options;

--- a/src/Microsoft.DotNet.CodeFormatting/FormattingEngine.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/FormattingEngine.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition.Convention;
 using System.Composition.Hosting;
 
@@ -17,23 +18,11 @@ namespace Microsoft.DotNet.CodeFormatting
             return engine;
         }
 
-        public static List<IRuleMetadata> GetFormattingRules()
+        public static ImmutableArray<IRuleMetadata> GetFormattingRules()
         {
             var container = CreateCompositionContainer();
-            var list = new List<IRuleMetadata>();
-            AppendRules<ISyntaxFormattingRule>(list, container);
-            AppendRules<ILocalSemanticFormattingRule>(list, container);
-            AppendRules<IGlobalSemanticFormattingRule>(list, container);
-            return list;
-        }
-
-        private static void AppendRules<T>(List<IRuleMetadata> list, CompositionHost container)
-            where T : IFormattingRule
-        {
-            foreach (var rule in container.GetExports<T>())
-            {
-                //list.Add(rule.Metadata);
-            }
+            var engine = container.GetExport<IFormattingEngine>();
+            return engine.AllRules;
         }
 
         private static CompositionHost CreateCompositionContainer()

--- a/src/Microsoft.DotNet.CodeFormatting/FormattingEngine.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/FormattingEngine.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition.Convention;
 using System.Composition.Hosting;
@@ -37,12 +36,22 @@ namespace Microsoft.DotNet.CodeFormatting
         private static ConventionBuilder GetConventions()
         {
             var conventions = new ConventionBuilder();
+
+            conventions.ForTypesDerivedFrom<IFormattingFilter>()
+                .Export<IFormattingFilter>();
+
             conventions.ForTypesDerivedFrom<ISyntaxFormattingRule>()
                 .Export<ISyntaxFormattingRule>();
             conventions.ForTypesDerivedFrom<ILocalSemanticFormattingRule>()
                 .Export<ILocalSemanticFormattingRule>();
             conventions.ForTypesDerivedFrom<IGlobalSemanticFormattingRule>()
                 .Export<IGlobalSemanticFormattingRule>();
+
+            conventions.ForType<Options>()
+                .Export();
+
+            conventions.ForTypesDerivedFrom<IFormattingEngine>()
+                .Export<IFormattingEngine>();
 
             return conventions;
         }

--- a/src/Microsoft.DotNet.CodeFormatting/FormattingEngineDiagnosticProvider.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/FormattingEngineDiagnosticProvider.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Microsoft.DotNet.CodeFormatting
+{
+    internal sealed partial class FormattingEngineImplementation
+    {
+        private class FormattingEngineDiagnosticProvider : FixAllContext.DiagnosticProvider
+        {
+            private readonly Project _project;
+            private List<Diagnostic> _allDiagnostics;
+
+            public FormattingEngineDiagnosticProvider(Project project, IEnumerable<Diagnostic> diagnostics)
+            {
+                _project = project;
+                _allDiagnostics = new List<Diagnostic>(diagnostics);
+            }
+
+            public override Task<IEnumerable<Diagnostic>> GetAllDiagnosticsAsync(Project project, CancellationToken cancellationToken)
+            {
+                if (project == _project)
+                {
+                    return Task.FromResult(_allDiagnostics.Where(d => true));
+                }
+
+                return Task.FromResult(Enumerable.Empty<Diagnostic>());
+            }
+
+            public override Task<IEnumerable<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(_allDiagnostics.Where(d => d.Location.SourceTree.FilePath == document.FilePath));
+            }
+
+            public override Task<IEnumerable<Diagnostic>> GetProjectDiagnosticsAsync(Project project, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(_allDiagnostics.Where(d => d.Location == Location.None));
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.CodeFormatting/FormattingEngineImplementation.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/FormattingEngineImplementation.cs
@@ -118,8 +118,7 @@ namespace Microsoft.DotNet.CodeFormatting
             return rules
                 .OrderBy(r => r.Metadata.Order)
                 .Where(r => _ruleMap[r.Metadata.Name])
-                .Select(r => r.CreateExport().Value)
-                .ToList();
+                .Select(r => r.CreateExport().Value);
         }
 
         private ImmutableDictionary<string, CodeFixProvider> CreateFixerMap()

--- a/src/Microsoft.DotNet.CodeFormatting/IFormatLogger.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/IFormatLogger.cs
@@ -2,10 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.CodeFormatting
 {

--- a/src/Microsoft.DotNet.CodeFormatting/IFormattingFilter.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/IFormattingFilter.cs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Threading.Tasks;
-
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.CodeFormatting

--- a/src/Microsoft.DotNet.CodeFormatting/IFormattingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/IFormattingRule.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/Microsoft.DotNet.CodeFormatting/IRuleMetadata.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/IRuleMetadata.cs
@@ -1,22 +1,16 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
-
 namespace Microsoft.DotNet.CodeFormatting
 {
     public interface IRuleMetadata
     {
-        [DefaultValue("")]
-        string Name { get; }
+        string Name { get; set; }
 
-        [DefaultValue("")]
-        string Description { get; }
+        string Description { get; set; }
 
-        [DefaultValue(int.MaxValue)]
-        int Order { get; }
+        int Order { get; set; }
 
-        [DefaultValue(true)]
-        bool DefaultRule { get; }
+        bool DefaultRule { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.CodeFormatting/Microsoft.DotNet.CodeFormatting.csproj
+++ b/src/Microsoft.DotNet.CodeFormatting/Microsoft.DotNet.CodeFormatting.csproj
@@ -69,6 +69,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FormattingEngineDiagnosticProvider.cs" />
+    <Compile Include="IRuleMetadata.cs" />
     <Compile Include="NameHelper.cs" />
     <Compile Include="ResponseFileWorkspace.cs" />
     <Compile Include="Rules\MarkReadonlyFieldsRule.cs" />
@@ -85,9 +86,8 @@
     <Compile Include="IFormattingRule.cs" />
     <Compile Include="Filters\IgnoreGeneratedFilesFilter.cs" />
     <Compile Include="Options.cs" />
-    <Compile Include="RuleAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="IRuleMetadata.cs" />
+    <Compile Include="RuleAttribute.cs" />
     <Compile Include="Rules\ExplicitVisibilityRule.CSharp.cs" />
     <Compile Include="Rules\ExplicitVisibilityRule.VisualBasic.cs" />
     <Compile Include="Rules\PrivateFieldNamingRule.CSharp.cs" />

--- a/src/Microsoft.DotNet.CodeFormatting/Microsoft.DotNet.CodeFormatting.csproj
+++ b/src/Microsoft.DotNet.CodeFormatting/Microsoft.DotNet.CodeFormatting.csproj
@@ -69,6 +69,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="FormattingEngineDiagnosticProvider.cs" />
     <Compile Include="NameHelper.cs" />
     <Compile Include="ResponseFileWorkspace.cs" />
     <Compile Include="Rules\MarkReadonlyFieldsRule.cs" />
@@ -108,6 +109,7 @@
     <Compile Include="Rules\NonAsciiCharactersAreEscapedInLiteralsRule.cs" />
     <Compile Include="Rules\ExplicitThisRule.cs" />
     <Compile Include="Rules\RuleOrder.cs" />
+    <Compile Include="UberCodeFixer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Microsoft.DotNet.CodeFormatting/Microsoft.DotNet.CodeFormatting.csproj
+++ b/src/Microsoft.DotNet.CodeFormatting/Microsoft.DotNet.CodeFormatting.csproj
@@ -41,7 +41,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
-    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Composition.AttributedModel">
       <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
     </Reference>

--- a/src/Microsoft.DotNet.CodeFormatting/Options.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Options.cs
@@ -2,12 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;
+using System.Composition;
 
 namespace Microsoft.DotNet.CodeFormatting
 {
     /// <summary>
     /// This is a MEF importable type which contains all of the options for formatting
     /// </summary>
+    [Shared]
     internal sealed class Options
     {
         internal ImmutableArray<string> CopyrightHeader { get; set; }

--- a/src/Microsoft.DotNet.CodeFormatting/Options.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Options.cs
@@ -1,13 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.ComponentModel.Composition;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Composition;
 
 namespace Microsoft.DotNet.CodeFormatting
 {
@@ -28,7 +23,7 @@ namespace Microsoft.DotNet.CodeFormatting
         internal IFormatLogger FormatLogger { get; set; }
 
         [ImportingConstructor]
-        internal Options()
+        public Options()
         {
             CopyrightHeader = FormattingDefaults.DefaultCopyrightHeader;
             FileNames = ImmutableArray<string>.Empty;

--- a/src/Microsoft.DotNet.CodeFormatting/Options.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Options.cs
@@ -2,14 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;
-using System.Composition;
 
 namespace Microsoft.DotNet.CodeFormatting
 {
     /// <summary>
     /// This is a MEF importable type which contains all of the options for formatting
     /// </summary>
-    [Export(typeof(Options))]
     internal sealed class Options
     {
         internal ImmutableArray<string> CopyrightHeader { get; set; }
@@ -22,7 +20,6 @@ namespace Microsoft.DotNet.CodeFormatting
 
         internal IFormatLogger FormatLogger { get; set; }
 
-        [ImportingConstructor]
         public Options()
         {
             CopyrightHeader = FormattingDefaults.DefaultCopyrightHeader;

--- a/src/Microsoft.DotNet.CodeFormatting/RuleAttribute.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/RuleAttribute.cs
@@ -9,79 +9,64 @@ namespace Microsoft.DotNet.CodeFormatting
 {
     [MetadataAttribute]
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
-    internal sealed class SyntaxRuleAttribute : ExportAttribute, IRuleMetadata
+    public class SyntaxRule : ExportAttribute, IRuleMetadata
     {
-        public SyntaxRuleAttribute(string name, string description, int order)
-            : base(typeof(ISyntaxFormattingRule))
-        {
-            Name = name;
-            Description = description;
-            Order = order;
-            DefaultRule = true;
-        }
+        [DefaultValue("")]
+        public string Name { get; set; }
 
         [DefaultValue("")]
-        public string Name { get; private set; }
-
-        [DefaultValue("")]
-        public string Description { get; private set; }
+        public string Description { get; set; }
 
         [DefaultValue(int.MaxValue)]
-        public int Order { get; private set; }
+        public int Order { get; set; }
 
         [DefaultValue(true)]
         public bool DefaultRule { get; set; }
+
+        public SyntaxRule() : base(typeof(ISyntaxFormattingRule))
+        {
+        }
     }
 
     [MetadataAttribute]
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
-    internal sealed class LocalSemanticRuleAttribute : ExportAttribute, IRuleMetadata
+    public class LocalSemanticRule : ExportAttribute, IRuleMetadata
     {
-        public LocalSemanticRuleAttribute(string name, string description, int order)
-            : base(typeof(ILocalSemanticFormattingRule))
-        {
-            Name = name;
-            Description = description;
-            Order = order;
-            DefaultRule = true;
-        }
+        [DefaultValue("")]
+        public string Name { get; set; }
 
         [DefaultValue("")]
-        public string Name { get; private set; }
-
-        [DefaultValue("")]
-        public string Description { get; private set; }
+        public string Description { get; set; }
 
         [DefaultValue(int.MaxValue)]
-        public int Order { get; private set; }
+        public int Order { get; set; }
 
         [DefaultValue(true)]
         public bool DefaultRule { get; set; }
+
+        public LocalSemanticRule() : base(typeof(ILocalSemanticFormattingRule))
+        {
+        }
     }
 
     [MetadataAttribute]
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
-    internal sealed class GlobalSemanticRuleAttribute : ExportAttribute, IRuleMetadata
+    public class GlobalSemanticRule : ExportAttribute, IRuleMetadata
     {
-        public GlobalSemanticRuleAttribute(string name, string description, int order)
-            : base(typeof(IGlobalSemanticFormattingRule))
-        {
-            Name = name;
-            Description = description;
-            Order = order;
-            DefaultRule = true;
-        }
+        [DefaultValue("")]
+        public string Name { get; set; }
 
         [DefaultValue("")]
-        public string Name { get; private set; }
-
-        [DefaultValue("")]
-        public string Description { get; private set; }
+        public string Description { get; set; }
 
         [DefaultValue(int.MaxValue)]
-        public int Order { get; private set; }
+        public int Order { get; set; }
 
         [DefaultValue(true)]
         public bool DefaultRule { get; set; }
+
+        public GlobalSemanticRule() : base(typeof(IGlobalSemanticFormattingRule))
+        {
+        }
     }
 }

--- a/src/Microsoft.DotNet.CodeFormatting/RuleAttribute.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/RuleAttribute.cs
@@ -2,12 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.ComponentModel.Composition;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Composition;
 
 namespace Microsoft.DotNet.CodeFormatting
 {

--- a/src/Microsoft.DotNet.CodeFormatting/RuleAttribute.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/RuleAttribute.cs
@@ -11,20 +11,17 @@ namespace Microsoft.DotNet.CodeFormatting
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public class SyntaxRule : ExportAttribute, IRuleMetadata
     {
-        [DefaultValue("")]
         public string Name { get; set; }
 
-        [DefaultValue("")]
         public string Description { get; set; }
 
-        [DefaultValue(int.MaxValue)]
         public int Order { get; set; }
 
-        [DefaultValue(true)]
         public bool DefaultRule { get; set; }
 
         public SyntaxRule() : base(typeof(ISyntaxFormattingRule))
         {
+            this.Initialize();
         }
     }
 
@@ -32,20 +29,17 @@ namespace Microsoft.DotNet.CodeFormatting
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public class LocalSemanticRule : ExportAttribute, IRuleMetadata
     {
-        [DefaultValue("")]
         public string Name { get; set; }
 
-        [DefaultValue("")]
         public string Description { get; set; }
 
-        [DefaultValue(int.MaxValue)]
         public int Order { get; set; }
 
-        [DefaultValue(true)]
         public bool DefaultRule { get; set; }
 
         public LocalSemanticRule() : base(typeof(ILocalSemanticFormattingRule))
         {
+            this.Initialize();
         }
     }
 
@@ -53,20 +47,28 @@ namespace Microsoft.DotNet.CodeFormatting
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public class GlobalSemanticRule : ExportAttribute, IRuleMetadata
     {
-        [DefaultValue("")]
         public string Name { get; set; }
 
-        [DefaultValue("")]
         public string Description { get; set; }
 
-        [DefaultValue(int.MaxValue)]
         public int Order { get; set; }
 
-        [DefaultValue(true)]
         public bool DefaultRule { get; set; }
 
         public GlobalSemanticRule() : base(typeof(IGlobalSemanticFormattingRule))
         {
+            this.Initialize();
+        }
+    }
+
+    internal static class IRuleMetadataExtensions
+    {
+        internal static void Initialize(this IRuleMetadata metadata)
+        {
+            metadata.Name = String.Empty;
+            metadata.Description = String.Empty;
+            metadata.Order = int.MaxValue;
+            metadata.DefaultRule = true;
         }
     }
 }

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/BraceNewLineRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/BraceNewLineRule.cs
@@ -1,19 +1,15 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+using System.Linq;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {
-    [SyntaxRule(BraceNewLineRule.Name, BraceNewLineRule.Description, SyntaxRuleOrder.BraceNewLineRule)]
+    [SyntaxRule(Name = BraceNewLineRule.Name, Description = BraceNewLineRule.Description, Order = SyntaxRuleOrder.BraceNewLineRule)]
     internal sealed class BraceNewLineRule : CSharpOnlyFormattingRule, ISyntaxFormattingRule
     {
         internal const string Name = "BraceNewLine";

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/CSharpOnlyFormattingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/CSharpOnlyFormattingRule.cs
@@ -2,11 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.CSharp.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.CSharp.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.CSharp.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.CSharp.cs
@@ -1,15 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
+using System.Collections.Immutable;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using System.Collections.Immutable;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.VisualBasic.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.VisualBasic.cs
@@ -1,15 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
-using System.ComponentModel.Composition;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
+using System.Collections.Immutable;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic;
-using System.Collections.Immutable;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.cs
@@ -3,11 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.Composition;
+using System.Composition;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Collections.Immutable;
+
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
@@ -169,7 +168,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
         private ImmutableArray<string> _cachedHeaderSource;
 
         [ImportingConstructor]
-        internal CopyrightHeaderRule(Options options)
+        public CopyrightHeaderRule(Options options)
         {
             _options = options;
         }

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {
-    [SyntaxRule(CopyrightHeaderRule.Name, CopyrightHeaderRule.Description, SyntaxRuleOrder.CopyrightHeaderRule)]
+    [SyntaxRule(Name = CopyrightHeaderRule.Name, Description = CopyrightHeaderRule.Description, Order = SyntaxRuleOrder.CopyrightHeaderRule)]
     internal sealed partial class CopyrightHeaderRule : SyntaxFormattingRule, ISyntaxFormattingRule
     {
         internal const string Name = FormattingDefaults.CopyrightRuleName;

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.cs
@@ -3,9 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Composition;
-using System.Linq;
 using System.Collections.Immutable;
+using System.Linq;
 
 using Microsoft.CodeAnalysis;
 
@@ -167,7 +166,6 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
         private ImmutableArray<string> _cachedHeader;
         private ImmutableArray<string> _cachedHeaderSource;
 
-        [ImportingConstructor]
         public CopyrightHeaderRule(Options options)
         {
             _options = options;

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/ExplicitThisRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/ExplicitThisRule.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -14,7 +11,7 @@ using Microsoft.CodeAnalysis.Simplification;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {
-    [LocalSemanticRule(ExplicitThisRule.Name, ExplicitThisRule.Description, LocalSemanticRuleOrder.RemoveExplicitThisRule)]
+    [LocalSemanticRule(Name = ExplicitThisRule.Name, Description = ExplicitThisRule.Description, Order = LocalSemanticRuleOrder.RemoveExplicitThisRule)]
     internal sealed class ExplicitThisRule : CSharpOnlyFormattingRule, ILocalSemanticFormattingRule
     {
         internal const string Name = "ExplicitThis";

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/ExplicitVisibilityRule.CSharp.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/ExplicitVisibilityRule.CSharp.cs
@@ -1,16 +1,15 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/ExplicitVisibilityRule.VisualBasic.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/ExplicitVisibilityRule.VisualBasic.cs
@@ -1,16 +1,15 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.VisualBasic;
-using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.VisualBasic;
+using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/ExplicitVisibilityRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/ExplicitVisibilityRule.cs
@@ -1,20 +1,15 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Microsoft.CodeAnalysis;
+
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {
-    [LocalSemanticRule(ExplicitVisibilityRule.Name, ExplicitVisibilityRule.Description, LocalSemanticRuleOrder.ExplicitVisibilityRule)]
+    [LocalSemanticRule(Name = ExplicitVisibilityRule.Name, Description = ExplicitVisibilityRule.Description, Order = LocalSemanticRuleOrder.ExplicitVisibilityRule)]
     internal sealed partial class ExplicitVisibilityRule : ILocalSemanticFormattingRule
     {
         internal const string Name = "ExplicitVisibility";

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/FormatDocumentFormattingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/FormatDocumentFormattingRule.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,14 +14,13 @@ using Microsoft.CodeAnalysis.VisualBasic;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {
-    [LocalSemanticRule(FormatDocumentFormattingRule.Name, FormatDocumentFormattingRule.Description, LocalSemanticRuleOrder.IsFormattedFormattingRule)]
+    [LocalSemanticRule(Name = FormatDocumentFormattingRule.Name, Description = FormatDocumentFormattingRule.Description, Order = LocalSemanticRuleOrder.IsFormattedFormattingRule)]
     internal sealed class FormatDocumentFormattingRule : ILocalSemanticFormattingRule
     {
         internal const string Name = "FormatDocument";
         internal const string Description = "Run the language specific formatter on every document";
         private readonly Options _options;
 
-        [ImportingConstructor]
         public FormatDocumentFormattingRule(Options options)
         {
             _options = options;

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/FormatDocumentFormattingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/FormatDocumentFormattingRule.cs
@@ -2,17 +2,15 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.ComponentModel.Composition;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.CSharp;
-using System.Linq;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System.Collections.Generic;
-using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.VisualBasic;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
@@ -25,7 +23,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
         private readonly Options _options;
 
         [ImportingConstructor]
-        internal FormatDocumentFormattingRule(Options options)
+        public FormatDocumentFormattingRule(Options options)
         {
             _options = options;
         }

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/HasNoCustomCopyrightHeaderFormattingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/HasNoCustomCopyrightHeaderFormattingRule.cs
@@ -3,12 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.Composition;
+using System.Composition;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -28,7 +26,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
         private readonly Options _options;
 
         [ImportingConstructor]
-        internal HasNoCustomCopyrightHeaderFormattingRule(Options options)
+        public HasNoCustomCopyrightHeaderFormattingRule(Options options)
         {
             _options = options;
         }

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/HasNoCustomCopyrightHeaderFormattingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/HasNoCustomCopyrightHeaderFormattingRule.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Composition;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -13,7 +12,7 @@ using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {
-    [SyntaxRule(HasNoCustomCopyrightHeaderFormattingRule.Name, HasNoCustomCopyrightHeaderFormattingRule.Description, SyntaxRuleOrder.HasNoCustomCopyrightHeaderFormattingRule)]
+    [SyntaxRule(Name = HasNoCustomCopyrightHeaderFormattingRule.Name, Description = HasNoCustomCopyrightHeaderFormattingRule.Description, Order = SyntaxRuleOrder.HasNoCustomCopyrightHeaderFormattingRule)]
     internal sealed class HasNoCustomCopyrightHeaderFormattingRule : CSharpOnlyFormattingRule, ISyntaxFormattingRule
     {
         internal const string Name = "CustomCopyright";
@@ -25,7 +24,6 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
 
         private readonly Options _options;
 
-        [ImportingConstructor]
         public HasNoCustomCopyrightHeaderFormattingRule(Options options)
         {
             _options = options;

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/HasNoIllegalHeadersFormattingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/HasNoIllegalHeadersFormattingRule.cs
@@ -15,7 +15,7 @@ using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {
-    [LocalSemanticRule(HasNoIllegalHeadersFormattingRule.Name, HasNoIllegalHeadersFormattingRule.Description, LocalSemanticRuleOrder.HasNoIllegalHeadersFormattingRule)]
+    [LocalSemanticRule(Name = HasNoIllegalHeadersFormattingRule.Name, Description = HasNoIllegalHeadersFormattingRule.Description, Order = LocalSemanticRuleOrder.HasNoIllegalHeadersFormattingRule)]
     internal sealed class HasNoIllegalHeadersFormattingRule : CSharpOnlyFormattingRule, ILocalSemanticFormattingRule
     {
         internal const string Name = "IllegalHeaders";

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/HasNoIllegalHeadersFormattingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/HasNoIllegalHeadersFormattingRule.cs
@@ -1,17 +1,17 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.Composition;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/MarkReadonlyFieldsRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/MarkReadonlyFieldsRule.cs
@@ -95,8 +95,8 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
         {
             private static readonly HashSet<string> s_serializingFieldAttributes = new HashSet<string>
             {
-                "System.ComponentModel.Composition.ImportAttribute",
-                "System.ComponentModel.Composition.ImportManyAttribute",
+                "System.Composition.ImportAttribute",
+                "System.Composition.ImportManyAttribute",
             };
 
             private readonly HashSet<IFieldSymbol> _fields = new HashSet<IFieldSymbol>();

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/MarkReadonlyFieldsRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/MarkReadonlyFieldsRule.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
     /// <summary>
     /// Mark any fields that can provably be marked as readonly.
     /// </summary>
-    [GlobalSemanticRule(MarkReadonlyFieldsRule.Name, MarkReadonlyFieldsRule.Description, GlobalSemanticRuleOrder.MarkReadonlyFieldsRule, DefaultRule = false)]
+    [GlobalSemanticRule(Name = MarkReadonlyFieldsRule.Name, Description = MarkReadonlyFieldsRule.Description, Order = GlobalSemanticRuleOrder.MarkReadonlyFieldsRule, DefaultRule = false)]
     internal sealed class MarkReadonlyFieldsRule : IGlobalSemanticFormattingRule
     {
         internal const string Name = "ReadonlyFields";

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/NewLineAboveRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/NewLineAboveRule.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
     /// <summary>
     /// Ensure there is a blank line above the first using and namespace in the file. 
     /// </summary>
-    [SyntaxRule(NewLineAboveRule.Name, NewLineAboveRule.Description, SyntaxRuleOrder.NewLineAboveFormattingRule)]
+    [SyntaxRule(Name = NewLineAboveRule.Name, Description = NewLineAboveRule.Description, Order = SyntaxRuleOrder.NewLineAboveFormattingRule)]
     internal sealed class NewLineAboveRule : CSharpOnlyFormattingRule, ISyntaxFormattingRule
     {
         internal const string Name = "NewLineAbove";

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/NewLineAboveRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/NewLineAboveRule.cs
@@ -1,13 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.ComponentModel.Composition;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/NonAsciiCharactersAreEscapedInLiteralsRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/NonAsciiCharactersAreEscapedInLiteralsRule.cs
@@ -1,12 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/NonAsciiCharactersAreEscapedInLiteralsRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/NonAsciiCharactersAreEscapedInLiteralsRule.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {
-    [SyntaxRule(NonAsciiCharactersAreEscapedInLiterals.Name, NonAsciiCharactersAreEscapedInLiterals.Description, SyntaxRuleOrder.NonAsciiChractersAreEscapedInLiterals)]
+    [SyntaxRule(Name = NonAsciiCharactersAreEscapedInLiterals.Name, Description = NonAsciiCharactersAreEscapedInLiterals.Description, Order = SyntaxRuleOrder.NonAsciiChractersAreEscapedInLiterals)]
     internal sealed class NonAsciiCharactersAreEscapedInLiterals : CSharpOnlyFormattingRule, ISyntaxFormattingRule
     {
         internal const string Name = FormattingDefaults.UnicodeLiteralsRuleName;

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/PrivateFieldNamingRule.CSharp.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/PrivateFieldNamingRule.CSharp.cs
@@ -1,14 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel.Composition;
 using System.Linq;
-using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/PrivateFieldNamingRule.VisualBasic.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/PrivateFieldNamingRule.VisualBasic.cs
@@ -1,17 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel.Composition;
 using System.Linq;
-using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Rename;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/PrivateFieldNamingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/PrivateFieldNamingRule.cs
@@ -2,11 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.ComponentModel.Composition;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/PrivateFieldNamingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/PrivateFieldNamingRule.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.Rename;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {
-    [GlobalSemanticRule(PrivateFieldNamingRule.Name, PrivateFieldNamingRule.Description, GlobalSemanticRuleOrder.PrivateFieldNamingRule)]
+    [GlobalSemanticRule(Name = PrivateFieldNamingRule.Name, Description = PrivateFieldNamingRule.Description, Order = GlobalSemanticRuleOrder.PrivateFieldNamingRule)]
     internal partial class PrivateFieldNamingRule : IGlobalSemanticFormattingRule
     {
         internal const string Name = "FieldNames";

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/RuleOrder.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/RuleOrder.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {
     // Please keep these values sorted by number, not rule name.    

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/SyntaxFormattingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/SyntaxFormattingRule.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.CodeAnalysis;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/UsingLocationRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/UsingLocationRule.cs
@@ -1,11 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.ComponentModel.Composition;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/UsingLocationRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/UsingLocationRule.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
     /// <summary>
     /// This will ensure that using directives are placed outside of the namespace.
     /// </summary>
-    [SyntaxRule(UsingLocationRule.Name, UsingLocationRule.Description, SyntaxRuleOrder.UsingLocationFormattingRule)]
+    [SyntaxRule(Name = UsingLocationRule.Name, Description = UsingLocationRule.Description, Order = SyntaxRuleOrder.UsingLocationFormattingRule)]
     internal sealed class UsingLocationRule : CSharpOnlyFormattingRule, ISyntaxFormattingRule
     {
         internal const string Name = "UsingLocation";

--- a/src/Microsoft.DotNet.CodeFormatting/UberCodeFixer.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/UberCodeFixer.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Microsoft.DotNet.CodeFormatting
+{
+    internal sealed partial class FormattingEngineImplementation
+    {
+        private class UberCodeFixer : CodeFixProvider
+        {
+            private ImmutableDictionary<string, CodeFixProvider> _fixerMap;
+
+            public UberCodeFixer(ImmutableDictionary<string, CodeFixProvider> fixerMap)
+            {
+                _fixerMap = fixerMap;
+            }
+
+            public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+            {
+                foreach (var diagnostic in context.Diagnostics)
+                {
+                    var fixer = _fixerMap[diagnostic.Id];
+                    await fixer.RegisterCodeFixesAsync(new CodeFixContext(context.Document, diagnostic, (a, d) => context.RegisterCodeFix(a, d), context.CancellationToken));
+                }
+            }
+
+            public override FixAllProvider GetFixAllProvider()
+            {
+                return null;
+            }
+
+            public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray<string>.Empty;
+        }
+    }
+}


### PR DESCRIPTION
The purpose of this change is to open up a spot in the code into which we can fit formatting operations based on Roslyn analyzers/code fixers. The Roslyn-based operations will exist side by side with the existing "rule"-based operations. By default, codeformatter will execute the rule-based operations. In the next commit, we will introduce a command-line switch to perform the analyzer/fixer-based operations instead. When all operations have been re-implemented as analyzer/fixers, we will remove the rule-based operations.

The switching points are in the methods `FormatProjectAsync` and `FormatSolutionAsync` in the `FormattingEngineImplementation` class.

For rule-based and analyzer/fixer-based operations to exist side by side, we must modify codeformatter to use MEF 2 instead of MEF 1, and that is actually the bulk of the changes in this PR. This is necessary because Roslyn code fixers use MEF 2 (because they must be portable, and MEF 1 is not available in portable .NET; only MEF 2 is available). I could have chosen to have codeformatter continue to use MEF 1 for the rule-based operations, and use MEF 2 only for the analyzer/fixer-based operations, but I felt this was too confusing.

Also:
- Remove unused usings and sort usings.
- Fix a bug in build.cmd where it would not update to the latest NuGet packages.

*Note* You might find it helpful to read the individual commit messages for more details on the rationale for some of the changes. The last commit -- a change to the `Options`  class -- is particularly subtle.

*Note* Although I have opened up seams in both the product code and the unit test code to accommodate analyzer/fixer-based operations, this PR does not actually include any such. That will come next.

@Priya91 @srivatsn 