### PR TITLE
Fix double new lines with extern directives

### DIFF
--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/NewLineAboveRuleTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/NewLineAboveRuleTests.cs
@@ -58,8 +58,8 @@ namespace NS1
             var text = @"#pragma warning disable 1591
 using System;";
 
-            var expected = @"
-#pragma warning disable 1591
+            var expected = @"#pragma warning disable 1591
+
 using System;";
 
             Verify(text, expected);
@@ -158,8 +158,8 @@ using System;
 ";
             var expected = @"
 // copyright comment
-
 #pragma warning disable 1591
+
 using System;
 ";
             Verify(text, expected);
@@ -228,6 +228,7 @@ namespace N { }
 using System;
 
 #pragma warning disable 1591
+
 namespace N { }
 ";
             Verify(text, expected);
@@ -244,6 +245,24 @@ namespace N { }
 namespace N { }
 ";
             Verify(text, text);
+        }
+
+        [Fact]
+        public void Issue83()
+        {
+            var text = @"
+extern alias PDB;
+using System;
+namespace N { }";
+
+            var expected = @"
+extern alias PDB;
+
+using System;
+
+namespace N { }";
+
+            Verify(text, expected);
         }
     }
 }

--- a/src/Microsoft.DotNet.CodeFormatting/SyntaxUtil.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/SyntaxUtil.cs
@@ -91,5 +91,20 @@ namespace Microsoft.DotNet.CodeFormatting
         {
             return trivia.IsKind(SyntaxKind.EndOfLineTrivia) || trivia.IsDirective;
         }
+
+        /// <summary>
+        /// Find the node directly before this in the parent.  Returns null in the case it 
+        /// cannot be found.
+        /// </summary>
+        internal static SyntaxNode FindPreviousNodeInParent(this SyntaxNode node)
+        {
+            var parent = node.Parent;
+            if (parent == null)
+            {
+                return null;
+            }
+
+            return parent.ChildNodes().Where(x => x.FullSpan.End == node.FullSpan.Start).FirstOrDefault();
+        }
     }
 }


### PR DESCRIPTION
Fix the double new lines which got inserted in the presence of an extern
directive in the code base.

Note: As a part of this change I had to completely revisit the new line
above rule because it didn't take into account a number of subtle
scenarios.  The rules around #pragma were simply making the
implementation very difficult to get correct and hence I decided to
change them to make it more managable.

closes #83