### PR TITLE
Disable the using location rule by default

### DIFF
--- a/src/Microsoft.DotNet.CodeFormatting/Rules/UsingLocationRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/UsingLocationRule.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
     /// <summary>
     /// This will ensure that using directives are placed outside of the namespace.
     /// </summary>
-    [SyntaxRule(UsingLocationRule.Name, UsingLocationRule.Description, SyntaxRuleOrder.UsingLocationFormattingRule)]
+    [SyntaxRule(UsingLocationRule.Name, UsingLocationRule.Description, SyntaxRuleOrder.UsingLocationFormattingRule, DefaultRule = false)]
     internal sealed class UsingLocationRule : CSharpOnlyFormattingRule, ISyntaxFormattingRule
     {
         internal const string Name = "UsingLocation";


### PR DESCRIPTION
Moving a using from inside a namespace to outside it is a fundamentally dangerous
operation.  In part because it changes the context of the lookup:

- Outside the namespace only the other usings are considered
- Inside the namespace the namespace + the usings are considered

This makes it trivial to create an error by moving a using directive around.

Instead of continuing to patch this rule I've decided to just disable it by
default for now.  We can revisit and make it safer later on but for now it
takes too much work to fix this.