### PR TITLE
Use document editor to fix formatting bug.

### DIFF
--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Analyzers/UnwrittenWritableFieldAnalyzerTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Analyzers/UnwrittenWritableFieldAnalyzerTests.cs
@@ -468,7 +468,7 @@ class C
 ";
             Verify(Original(text), Readonly(text));
         }
-#if NOT_YET_PASSING
+
         [Fact]
         public void TestMarkReadonlyWithFieldWithNoAccessSpecifierPrecededByXmlComment()
         {
@@ -481,7 +481,7 @@ class C
 ";
             Verify(Original(text), Readonly(text));
         }
-#endif
+
         private static string Original(string text)
         {
             return text.Replace("READONLY ", "");

--- a/src/Microsoft.DotNet.CodeFormatting/Analyzers/UnwrittenWritableFieldFixer.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Analyzers/UnwrittenWritableFieldFixer.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Text;
@@ -20,8 +19,6 @@ namespace Microsoft.DotNet.CodeFormatting.Analyzers
     [ExportCodeFixProvider(LanguageNames.CSharp)]
     public class UnwrittenWritableFieldThisFixer : CodeFixProvider
     {
-        private static readonly SyntaxToken s_readOnlyToken =  SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword);
-
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
@@ -43,9 +40,6 @@ namespace Microsoft.DotNet.CodeFormatting.Analyzers
 
         private async Task<Document> AddReadonlyModifier(Document document, SyntaxNode root, FieldDeclarationSyntax fieldDeclaration, CancellationToken cancellationToken)
         {
-            SemanticModel model = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            ISymbol fieldSymbol = model.GetDeclaredSymbol(fieldDeclaration, cancellationToken);
-
             var docEditor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
             var modifiers = docEditor.Generator.GetModifiers(fieldDeclaration);
             docEditor.SetModifiers(fieldDeclaration, modifiers + DeclarationModifiers.ReadOnly);


### PR DESCRIPTION
This fixes a bug where, if the field had no other modifiers, and the field declaration was preceded by a comment, the "readonly" keyword would be inserted above the comment.