### PR TITLE
Copy CopyrightHeader.md and IllegalHeaders.md to the correct output location

### DIFF
--- a/src/CodeFormatter/CodeFormatter.csproj
+++ b/src/CodeFormatter/CodeFormatter.csproj
@@ -83,9 +83,15 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="CopyrightHeader.md">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="IllegalHeaders.md">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
     <None Include="App.config" />
-    <None Include="CopyrightHeader.md" />
-    <None Include="IllegalHeaders.md" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -103,8 +109,4 @@
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>  -->
-  <Target Name="AfterBuild">
-    <Copy SourceFiles="$(ProjectDir)IllegalHeaders.md" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
-    <Copy SourceFiles="$(ProjectDir)CopyrightHeader.md" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
-  </Target>
 </Project>


### PR DESCRIPTION
Changed CopyrightHeader.md and IllegalHeaders.md from <None> items to <Content> items because they are files that are used by the output binaries. Use msbuild's builtin <CopyToOutputDirectory> instead of having a manual copy step. Fixes #103.