### PR TITLE
Add explicit reference to System.Threading.Tasks.Dataflow package, v4…

### DIFF
--- a/src/CodeFormatter/CodeFormatter.csproj
+++ b/src/CodeFormatter/CodeFormatter.csproj
@@ -71,6 +71,10 @@
       <HintPath>..\packages\System.Reflection.Metadata.1.0.21\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.5.25.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Dataflow.4.5.25\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -86,7 +90,9 @@
     <None Include="App.config" />
     <None Include="CopyrightHeader.md" />
     <None Include="IllegalHeaders.md" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.CodeFormatting\Microsoft.DotNet.CodeFormatting.csproj">

--- a/src/CodeFormatter/packages.config
+++ b/src/CodeFormatter/packages.config
@@ -11,4 +11,5 @@
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net45" />
+  <package id="System.Threading.Tasks.Dataflow" version="4.5.25" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Adds an explicit reference to the System.Threading.Tasks.Dataflow package, v4.5.25, recently released. Works around a current MSBUILD issue where this indirect dependency doesn't get copied to the build output directory (with the result that xcopy deployments can fail due to missing assembly).