### PR TITLE
Anfix fix copyright default

### DIFF
--- a/src/CodeFormatter/FormatOptions.cs
+++ b/src/CodeFormatter/FormatOptions.cs
@@ -1,10 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 
 using CommandLine;
+
+using Microsoft.DotNet.CodeFormatting;
 
 namespace CodeFormatter
 {
@@ -37,7 +41,7 @@ namespace CodeFormatter
         [Option(
             "copyright", 
             HelpText = "Specifies file containing copyright header.")]
-        public string CopyrightHeader { get; set;  }
+        public string CopyrightHeaderFile { get; set;  }
 
         [Option(
             "enable", 
@@ -65,6 +69,35 @@ namespace CodeFormatter
             "useanalyzers",
             HelpText = "TEMPORARY: invoke built-in analyzers rather than rules to perform reformatting.")]
         public bool UseAnalyzers { get; set; }
+
+        private ImmutableArray<string> _copyrightHeaderText;
+        public ImmutableArray<string> CopyrightHeaderText
+        {
+            get
+            {
+                if (_copyrightHeaderText == null)
+                {
+                    _copyrightHeaderText = InitializeCopyrightHeaderText(CopyrightHeaderFile);
+                }
+                return _copyrightHeaderText;
+            }
+            internal set
+            {
+                _copyrightHeaderText = value;
+            }
+        }
+
+        private static ImmutableArray<string> InitializeCopyrightHeaderText(string copyrightHeaderFile)
+        {
+            ImmutableArray<string> copyrightHeaderText = FormattingDefaults.DefaultCopyrightHeader;
+
+            if (!String.IsNullOrEmpty(copyrightHeaderFile))
+            {
+                copyrightHeaderText = ImmutableArray.CreateRange(File.ReadAllLines(copyrightHeaderFile));
+            }
+
+            return copyrightHeaderText;
+        }
 
         private ImmutableDictionary<string, bool> _ruleMap;
         public ImmutableDictionary<string, bool> RuleMap

--- a/src/CodeFormatter/Program.cs
+++ b/src/CodeFormatter/Program.cs
@@ -33,7 +33,6 @@ namespace CodeFormatter
                 (ListOptions listOptions) => RunListCommand(listOptions),
                 (FormatOptions formatOptions) => RunFormatCommand(formatOptions),
                 errs => 1);
-
         }
 
         private static int RunListCommand(ListOptions options)
@@ -111,10 +110,10 @@ namespace CodeFormatter
             configBuilder.Add(options.PreprocessorConfigurations.ToArray());            
             engine.PreprocessorConfigurations = configBuilder.ToImmutableArray();
 
-            engine.FileNames = options.Files.ToImmutableArray();
-            engine.CopyrightHeader = ImmutableArray.ToImmutableArray<string>(new string[] { options.CopyrightHeader });
-            engine.AllowTables = options.DefineDotNetFormatter;
             engine.Verbose = options.Verbose;
+            engine.AllowTables = options.DefineDotNetFormatter;
+            engine.FileNames = options.Files.ToImmutableArray();
+            engine.CopyrightHeader = options.CopyrightHeaderText;
 
             if (options.UseAnalyzers)
             {

--- a/src/CodeFormatter/Properties/AssemblyInfo.cs
+++ b/src/CodeFormatter/Properties/AssemblyInfo.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 [assembly: AssemblyCopyright("\x00a9 Microsoft Corporation.  All rights reserved.")]
 [assembly: AssemblyCompany("Microsoft Corporation")]
@@ -17,3 +15,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+

--- a/src/Microsoft.DotNet.CodeFormatting/FormattingDefaults.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/FormattingDefaults.cs
@@ -1,19 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.CodeFormatting
 {
     public static class FormattingDefaults
     {
-        public const string UnicodeLiteralsRuleName = "UnicodeLiterals";
         public const string CopyrightRuleName = "Copyright";
+        public const string UnicodeLiteralsRuleName = "UnicodeLiterals";
 
         private static readonly string[] s_defaultCopyrightHeader =
         {

--- a/src/Microsoft.DotNet.CodeFormatting/FormattingEngineImplementation.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/FormattingEngineImplementation.cs
@@ -110,6 +110,8 @@ namespace Microsoft.DotNet.CodeFormatting
             _localSemanticRules = localSemanticRules;
             _globalSemanticRules = globalSemanticRules;
 
+            Debug.Assert(options.CopyrightHeader != null);
+
             foreach (var rule in AllRules)
             {
                 _ruleEnabledMap[rule.Name] = rule.DefaultRule;


### PR DESCRIPTION
Command-line parsing library update broke the copyright header option. This is due to the fact that we don't have unit-testing that covers the driver -> code formatter rules and analyzers path. I will fix this after discussing approach with the team. In the meantime, here's a fix for the copyright header issue.

@lgolding @srivatsn @Priya91 @jaredpar 