### PR TITLE
Fix ProvideExplicitVariableTypeAnalyzer

### DIFF
--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers.Tests/ProvideExplicitVariableTypeAnalyzerTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers.Tests/ProvideExplicitVariableTypeAnalyzerTests.cs
@@ -402,5 +402,24 @@ class C1
             const string expected = input;
             Verify(input, expected, runFormatter: false);
         }
+
+        [Fact]
+        public void TestVarDeclarationWithMissingNodes()
+        {
+            const string input = @"
+class C1
+{
+    void M()
+    {
+        var x = ;
+        var = 10;
+        var y 10;
+        foreach (var z in ){}
+        foreach (var in ){}
+    }
+}";
+            const string expected = input;
+            Verify(input, expected, runFormatter: false);
+        }
     }
 }

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/ProvideExplicitVariableTypeAnalyzer.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/ProvideExplicitVariableTypeAnalyzer.cs
@@ -101,9 +101,13 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
         //       which is (presumbly) much slower. 
         private static bool IsTypeObvious(SyntaxNode node)
         {            
-            if (node == null)
+            // Since parser would generate the missing node (IsMissing == true) and attach a diagnostic to it,
+            // we traverse the sub tree only if a diagnostic is attached as optimization
+            if (node == null || 
+               (node.ContainsDiagnostics && 
+                node.DescendantNodesAndTokensAndSelf().Where(n => n.IsMissing).Any()))
             {
-                return false;
+                return true;
             }
                                                    
             ExpressionSyntax expressionNode = node is VariableDeclarationSyntax ?

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/ProvideExplicitVariableTypeAnalyzer.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/ProvideExplicitVariableTypeAnalyzer.cs
@@ -100,12 +100,8 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
         //       The trade-off here is the logic we use to check syntax node is not as accurate as a query to SemanticModel, 
         //       which is (presumbly) much slower. 
         private static bool IsTypeObvious(SyntaxNode node)
-        {            
-            // Since parser would generate the missing node (IsMissing == true) and attach a diagnostic to it,
-            // we traverse the sub tree only if a diagnostic is attached as optimization
-            if (node == null || 
-               (node.ContainsDiagnostics && 
-                node.DescendantNodesAndTokensAndSelf().Where(n => n.IsMissing).Any()))
+        {   
+            if (node == null)
             {
                 return true;
             }
@@ -114,15 +110,21 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
                                 ((VariableDeclarationSyntax)node)?.Variables.FirstOrDefault()?.Initializer?.Value :
                                 (node as ForEachStatementSyntax)?.Expression;
 
-            // 'expressionNode == null' means the code under inspection has errors,
-            // so we return 'true' to avoid firing a warning.
             return expressionNode == null ?
+                   // 'expressionNode == null' means the code under inspection has errors,
+                   // so we return 'true' to avoid firing a warning.
                    true :
+                   // Check for obvious type.
                    expressionNode.Kind() == SyntaxKind.AsExpression ||
                    expressionNode is LiteralExpressionSyntax ||
                    expressionNode is CastExpressionSyntax ||
                    expressionNode is ObjectCreationExpressionSyntax ||
-                   expressionNode is ArrayCreationExpressionSyntax;
+                   expressionNode is ArrayCreationExpressionSyntax ||
+                   // Check if there's any missing node in the subtree.
+                   // Since parser would generate the missing node (IsMissing == true) and attach a diagnostic to it,
+                   // we traverse the subtree only if a diagnostic is attached as optimization.
+                   (node.ContainsDiagnostics &&
+                    node.DescendantNodesAndTokensAndSelf().Where(n => n.IsMissing).Any());
         }
     }
 }


### PR DESCRIPTION
Fix `ProvideExplicitVariableTypeAnalyzer` to handle errors properly
- Make analyzer ignore the node with miss nodes in sub-tree.
- Add corresponding tests.

@tmeschter @srivatsn @michaelcfanning @lgolding @jaredpar @Priya91 