### PR TITLE
Preserve leading trivia when deleting TestClassAttribute

### DIFF
--- a/src/XUnitConverter.Tests/MSTestToXUnitConverterTests.cs
+++ b/src/XUnitConverter.Tests/MSTestToXUnitConverterTests.cs
@@ -104,6 +104,42 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
+        public async Task TestPreserveClassDocComments()
+        {
+            string text = @"
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace System.Composition.UnitTests
+{
+    /// <summary>
+    /// Some sort of doc comment.
+    /// </summary>
+    [TestClass]
+    public class MyTestClass
+    {
+    }
+}
+";
+            var expected = @"
+using System;
+using Xunit;
+
+namespace System.Composition.UnitTests
+{
+    /// <summary>
+    /// Some sort of doc comment.
+    /// </summary>
+    public class MyTestClass
+    {
+    }
+}
+";
+            await Verify(text, expected);
+        }
+
+
+        [Fact]
         public async Task TestUpdatesTestMethodAttributes()
         {
             var text = @"

--- a/src/XUnitConverter/MSTestToXUnitConverter.cs
+++ b/src/XUnitConverter/MSTestToXUnitConverter.cs
@@ -163,7 +163,7 @@ namespace XUnitConverter
                     }
                     else
                     {
-                        transformationRoot = transformationRoot.RemoveNode(attributeListSyntax, SyntaxRemoveOptions.KeepNoTrivia);
+                        transformationRoot = transformationRoot.RemoveNode(attributeListSyntax, SyntaxRemoveOptions.KeepLeadingTrivia);
                     }
                 }
                 return transformationRoot;


### PR DESCRIPTION
I noticed diffs of the form:

```
-    /// <summary>
-    /// Verify the functioning of the BuildErrorEventArg class.
-    /// </summary>
-    [TestClass]
```

Where not only was the not-needed-in-xunit attribute removed, but its
removal also deleted class-level doc comments.  This change preserves
leading trivia on the deleted AttributeList.  That trivia is normally
blank (so this doesn't break the existing scenario), but a leading comment
or doc comment will be present there.