### PR TITLE
Skip projects that don't have any documents.

### DIFF
--- a/src/Microsoft.DotNet.CodeFormatting/FormattingEngineImplementation.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/FormattingEngineImplementation.cs
@@ -201,6 +201,12 @@ namespace Microsoft.DotNet.CodeFormatting
 
         public async Task FormatProjectWithAnalyzersAsync(Project project, CancellationToken cancellationToken)
         {
+            if (!project.Documents.Any())
+            {
+                FormatLogger.WriteLine($"Skipping {project.Name}: no files to format.");
+                return;
+            }
+
             var watch = new Stopwatch();
             watch.Start();
 


### PR DESCRIPTION
This prevents a "sequence has no elements" exception when we access `projects.Documents.First()`.