### PR TITLE
Upgrade to CommandLineParser 2.0.273-beta

### DIFF
--- a/src/CodeFormatter/CodeFormatter.csproj
+++ b/src/CodeFormatter/CodeFormatter.csproj
@@ -17,8 +17,8 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CommandLine, Version=2.0.207.0, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
-      <HintPath>..\packages\CommandLineParser.2.0.207-alpha\lib\net45\CommandLine.dll</HintPath>
+    <Reference Include="CommandLine, Version=2.0.273.0, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommandLineParser.2.0.273-beta\lib\net45\CommandLine.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -96,7 +96,9 @@
     <None Include="App.config" />
     <None Include="CopyrightHeader.md" />
     <None Include="IllegalHeaders.md" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.CodeFormatter.Analyzers\Microsoft.DotNet.CodeFormatter.Analyzers.csproj">

--- a/src/CodeFormatter/Program.cs
+++ b/src/CodeFormatter/Program.cs
@@ -26,12 +26,12 @@ namespace CodeFormatter
         private const int SUCCEEDED = 0;
 
         private static int Main(string[] args)
-        {            
+        {
             return Parser.Default.ParseArguments<
-                ListOptions, 
+                ListOptions,
                 ExportOptions,
                 FormatOptions>(args)
-              .Return(
+            .MapResult(
                 (ListOptions listOptions) => RunListCommand(listOptions),
                 (ExportOptions exportOptions) => RunExportOptionsCommand(exportOptions),
                 (FormatOptions formatOptions) => RunFormatCommand(formatOptions),

--- a/src/CodeFormatter/packages.config
+++ b/src/CodeFormatter/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommandLineParser" version="2.0.207-alpha" targetFramework="net452" />
+  <package id="CommandLineParser" version="2.0.273-beta" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net45" />

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers.Tests/Microsoft.DotNet.CodeFormatter.Analyzers.Tests.csproj
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers.Tests/Microsoft.DotNet.CodeFormatter.Analyzers.Tests.csproj
@@ -11,6 +11,10 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CommandLine, Version=2.0.273.0, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommandLineParser.2.0.273-beta\lib\net45\CommandLine.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
@@ -116,7 +120,9 @@
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers.Tests/packages.config
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommandLineParser" version="2.0.207-alpha" targetFramework="net452" />
+  <package id="CommandLineParser" version="2.0.273-beta" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net45" />

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/FormatOptionsParsingTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/FormatOptionsParsingTests.cs
@@ -9,7 +9,6 @@ using CodeFormatter;
 using CommandLine;
 
 using Xunit;
-using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.DotNet.CodeFormatting.Tests
 {
@@ -31,7 +30,7 @@ namespace Microsoft.DotNet.CodeFormatting.Tests
             // at least two verbs to ParseArguments in order to realize appropriate
             // behavior around parsing the verb name...
             result = parser.ParseArguments<ExportOptions, FormatOptions>(args)
-                .Return(
+                .MapResult(
                 (FormatOptions parsedOptions) => { options = parsedOptions; return 0; },
                 errs => ReportErrors(errs));
 

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Microsoft.DotNet.CodeFormatting.Tests.csproj
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Microsoft.DotNet.CodeFormatting.Tests.csproj
@@ -14,9 +14,9 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
-    <Reference Include="CommandLine, Version=2.0.207.0, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\CommandLineParser.2.0.207-alpha\lib\net45\CommandLine.dll</HintPath>
+    <Reference Include="CommandLine, Version=2.0.273.0, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommandLineParser.2.0.273-beta\lib\net45\CommandLine.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/packages.config
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CommandLineParser" version="2.0.273-beta" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net45" />


### PR DESCRIPTION
... for consistency with Coby. The reason this matters is that both Coby tools and CodeFormatter.exe are uploaded to Azure for use by Coby; all the binaries go to the same directory, so they need to all use the same versions of packages that they have in common.

@michaelcfanning @jinujoseph 