### PR TITLE
Added handling for InvalidProjectFileExpception

### DIFF
--- a/src/CodeFormatter/Program.cs
+++ b/src/CodeFormatter/Program.cs
@@ -70,15 +70,23 @@ namespace CodeFormatter
             }
             catch (AggregateException ex)
             {
-                var typeLoadException = ex.InnerExceptions.FirstOrDefault() as ReflectionTypeLoadException;
-                if (typeLoadException == null)
+                var typeLoadException = ex.InnerExceptions.OfType<ReflectionTypeLoadException>().FirstOrDefault();
+                var invalidProjextFileException = ex.InnerExceptions.FirstOrDefault(innerEx => innerEx.GetType().FullName == "Microsoft.Build.Exceptions.InvalidProjectFileException");
+                if (typeLoadException == null && invalidProjextFileException == null)
                     throw;
 
-                Console.WriteLine("ERROR: Type loading error detected. In order to run this tool you need either Visual Studio 2015 or Microsoft Build Tools 2015 tools installed.");
-                var messages = typeLoadException.LoaderExceptions.Select(e => e.Message).Distinct();
-                foreach (var message in messages)
-                    Console.WriteLine("- {0}", message);
-
+                if (typeLoadException != null)
+                {
+                    Console.WriteLine("ERROR: Type loading error detected. In order to run this tool you need either Visual Studio 2015 or Microsoft Build Tools 2015 tools installed.");
+                    var messages = typeLoadException.LoaderExceptions.Select(e => e.Message).Distinct();
+                    foreach (var message in messages)
+                        Console.WriteLine("- {0}", message);
+                }
+                if (invalidProjextFileException != null)
+                {
+                    Console.WriteLine("ERROR: Projectfile could not be loaded.");
+                    Console.WriteLine("- {0}", invalidProjextFileException.Message);
+                }
                 return 1;
             }
         }
@@ -106,7 +114,7 @@ namespace CodeFormatter
         }
 
         private static async Task RunFormatItemAsync(IFormattingEngine engine, string item, string language, CancellationToken cancellationToken)
-        { 
+        {
             Console.WriteLine(Path.GetFileName(item));
             string extension = Path.GetExtension(item);
             if (StringComparer.OrdinalIgnoreCase.Equals(extension, ".rsp"))


### PR DESCRIPTION
The intent is to support automatic fomatting of a repository. CodeFormatter is called by a script for each commit. When a commit has invalid project files, CodeFormatter should exit in a clean way and provide a error code.

To avoid a hard crash of CodeFormatter, the exception  Microsoft.Build.Exceptions.InvalidProjectFileException must be handled.

The exception type is checked by name to avoid a compiletime dependency for a specific version of Microsoft.Build.
The dependency is brought in by roslyn and CodeFormatter does not know which version has to be used. A different approach could be to add the reference and write tests around this to check that the correct version is referenced.