### PR TITLE
Fix bug in ProvideExplicitVariableTypeAnalyzer

### DIFF
--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers.Tests/ProvideExplicitVariableTypeAnalyzerTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers.Tests/ProvideExplicitVariableTypeAnalyzerTests.cs
@@ -243,7 +243,7 @@ class C1
 {
     int[][] T()
     {
-        return new int[] { new int[] { 1, 2, 3 }, new int[] { 4, 5, 6 } }
+        return new int[] { new int[] { 1, 2, 3 }, new int[] { 4, 5, 6 } };
     }
 
     void M(string[] a)
@@ -253,6 +253,9 @@ class C1
  
         foreach (var element in T())
         { }
+
+        foreach (var i in 1)
+        { }
     }
 }";
             const string expected = @"
@@ -260,7 +263,7 @@ class C1
 {
     int[][] T()
     {
-        return new int[] { new int[] { 1, 2, 3 }, new int[] { 4, 5, 6 } }
+        return new int[] { new int[] { 1, 2, 3 }, new int[] { 4, 5, 6 } };
     }
 
     void M(string[] a)
@@ -269,6 +272,9 @@ class C1
         { }  
  
         foreach (int[] element in T())
+        { }
+
+        foreach (var i in 1)
         { }
     }
 }";
@@ -297,6 +303,8 @@ class C1
         public void TestVarDeclarationInUsing()
         {
             const string input = @"
+using System;
+
 class C1
 {
     class U1 : IDisposable
@@ -322,6 +330,8 @@ class C1
     }
 }";
             const string expected = @"
+using System;
+
 class C1
 {
     class U1 : IDisposable
@@ -423,6 +433,42 @@ class C1
     }
 }";
             const string expected = input;
+            Verify(input, expected, runFormatter: false);
+        }
+
+        [Fact]
+        public void TestVarDeclarationGeneric()
+        {
+            const string input = @"
+using System.Collections.Generic;
+//using System.Collections.Immutable;   // this line is intentionally commented out
+
+class C2
+{}
+
+class C1
+{
+    void M()
+    {
+        var x = (new List<int>()).GetEnumerator();
+        var locationBuilder = ImmutableArray.CreateBuilder<C2>();
+    }
+}";
+            const string expected = @"
+using System.Collections.Generic;
+//using System.Collections.Immutable;   // this line is intentionally commented out
+
+class C2
+{}
+
+class C1
+{
+    void M()
+    {
+        List<int>.Enumerator x = (new List<int>()).GetEnumerator();
+        var locationBuilder = ImmutableArray.CreateBuilder<C2>();
+    }
+}";
             Verify(input, expected, runFormatter: false);
         }
     }

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/ProvideExplicitVariableTypeAnalyzer.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/ProvideExplicitVariableTypeAnalyzer.cs
@@ -12,6 +12,8 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
 
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+
 namespace Microsoft.DotNet.CodeFormatter.Analyzers
 {
     [Export(typeof(DiagnosticAnalyzer))]
@@ -89,12 +91,8 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
             }, SyntaxKind.ForEachStatement);
         }
 
-        private static bool HasErrors(SyntaxNode node, SemanticModel model, CancellationToken token)
-        {
-            return model.GetSyntaxDiagnostics(node.Span, token).Any(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error) ||
-                   model.GetDeclarationDiagnostics(node.Span, token).Any(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error) ||
-                   model.GetMethodBodyDiagnostics(node.Span, token).Any(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
-        }
+        private static bool HasErrors(SyntaxNode node, SemanticModel model, CancellationToken token) => 
+            model.GetTypeInfo(node, token).Type.Kind != SymbolKind.ErrorType;
 
         private static bool RuleEnabled(SyntaxNodeAnalysisContext syntaxContext)
         {
@@ -109,7 +107,7 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
         /// </summary>
         private static bool IsAnonymousType(SyntaxNode node, SemanticModel model, CancellationToken cancellationToken)
         {
-            ISymbol symbol = model.GetDeclaredSymbol(node, cancellationToken); 
+            ISymbol symbol = model.GetDeclaredSymbol(node, cancellationToken);
             bool? isAnonymousType = ((ILocalSymbol)symbol)?.Type?.IsAnonymousType;
             return isAnonymousType.HasValue && isAnonymousType.Value;
         }

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/CodeFormattingTestBase.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/CodeFormattingTestBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -16,6 +17,7 @@ namespace Microsoft.DotNet.CodeFormatting.Tests
     {
         private static readonly MetadataReference s_CorlibReference = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
         private static readonly MetadataReference s_SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
+        private static readonly MetadataReference s_SystemCollectionsImmutableReference = MetadataReference.CreateFromFile(typeof(ImmutableArray).Assembly.Location);
         private static readonly MetadataReference s_CodeFormatterReference = MetadataReference.CreateFromFile(typeof(IFormattingEngine).Assembly.Location);
 
         private const string FileNamePrefix = "Test";
@@ -28,6 +30,7 @@ namespace Microsoft.DotNet.CodeFormatting.Tests
             yield return s_CorlibReference;
             yield return s_SystemCoreReference;
             yield return s_CodeFormatterReference;
+            yield return s_SystemCollectionsImmutableReference;
         }
 
         private Workspace CreateWorkspace(string[] sources, string language = LanguageNames.CSharp)


### PR DESCRIPTION
That is caused by not checking if the code has syntax/binding errors. This might fixes https://github.com/dotnet/codeformatter/issues/185 (I could only repro the bug by introducing errors, which might not be the original cause of this issue).

@michaelcfanning @srivatsn @lgolding @mavasani 