### PR TITLE
Introduce local\global classification for rules based on analyzers

### DIFF
--- a/src/CodeFormatter/App.config
+++ b/src/CodeFormatter/App.config
@@ -37,6 +37,34 @@
         <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-0.7.0.0" newVersion="0.7.0.0" />
       </dependentAssembly>
+      <dependentAssembly>  
+       <assemblyIdentity name="Microsoft.Build.Engine" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>  
+       <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="14.0.0.0"/>  
+     </dependentAssembly>  
+     <dependentAssembly>  
+       <assemblyIdentity name="Microsoft.Build" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>  
+       <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="14.0.0.0"/>  
+     </dependentAssembly>  
+     <dependentAssembly>  
+       <assemblyIdentity name="Microsoft.Build.Conversion.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>  
+       <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="14.0.0.0"/>  
+     </dependentAssembly>  
+     <dependentAssembly>  
+       <assemblyIdentity name="Microsoft.Build.Tasks.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>  
+       <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="14.0.0.0"/>  
+     </dependentAssembly>  
+     <dependentAssembly>  
+       <assemblyIdentity name="Microsoft.Build.Utilities.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>  
+       <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="14.0.0.0"/>  
+     </dependentAssembly>  
+     <dependentAssembly>  
+       <assemblyIdentity name="Microsoft.CompactFramework.Build.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>  
+       <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="9.0.0.0"/>  
+     </dependentAssembly>  
+     <dependentAssembly>  
+       <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>  
+       <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="14.0.0.0"/>  
+     </dependentAssembly>  
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers.Tests/Microsoft.DotNet.CodeFormatter.Analyzers.Tests.csproj
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers.Tests/Microsoft.DotNet.CodeFormatter.Analyzers.Tests.csproj
@@ -88,6 +88,7 @@
     <Compile Include="AnalyzerFixerTestBase.cs" />
     <Compile Include="ExplicitThisAnalyzerTests.cs" />
     <Compile Include="OptimizeNamespaceImportsTests.cs" />
+    <Compile Include="PlaceImportsOutsideNamespaceTests.cs" />
     <Compile Include="UnwrittenWritableFieldAnalyzerTests.cs" />
     <Compile Include="ProvideExplicitVariableTypeAnalyzerTests.cs" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers.Tests/PlaceImportsOutsideNamespaceTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers.Tests/PlaceImportsOutsideNamespaceTests.cs
@@ -1,0 +1,149 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis.Options;
+
+using Xunit;
+
+namespace Microsoft.DotNet.CodeFormatter.Analyzers.Tests
+{
+    public sealed class PlaceImportsOutsideNamespaceTests : AnalyzerFixerTestBase
+    {
+        public PlaceImportsOutsideNamespaceTests()
+        {
+            OptionsHelper.GetPropertiesImplementation = (analyzerOptions) =>
+            {
+                PropertyBag properties = CreatePolicyThatDisablesAllAnalysis();
+                properties.SetProperty(OptionsHelper.BuildDefaultEnabledProperty(PlaceImportsOutsideNamespaceAnalyzer.AnalyzerName), true);
+                return properties;
+            };
+        }
+
+        [Fact]
+        public void PlaceImportsOutsideNamespace_Simple()
+        {
+            string input = @"
+namespace N1
+{
+    using System.Runtime.InteropServices;
+    using AnotherUnreferencedNamespace;
+    using System.Threading;
+    using System;
+    using System.IO;
+    using System.Xml;
+
+    public class Test
+    {
+        public static void Main()
+        {
+            Console.WriteLine(""Calling Console.WriteLine, a dependency on System namespace."");
+        }
+    }
+}
+";
+
+            string expected = @"
+using System.Runtime.InteropServices;
+using System.Threading;
+using System;
+using System.IO;
+
+namespace N1
+{
+    using AnotherUnreferencedNamespace;
+    using System.Xml;
+
+    public class Test
+    {
+        public static void Main()
+        {
+            Console.WriteLine(""Calling Console.WriteLine, a dependency on System namespace."");
+        }
+    }
+}
+";
+            Verify(input, expected, runFormatter: false);
+        }
+
+        [Fact]
+        public void PlaceImportsOutsideNamespace_AddToExisting()
+        {
+            string input = @"
+using System.Runtime.InteropServices;
+
+namespace N1
+{
+    using System;
+    using System.IO;
+
+    public class Test
+    {
+        public static void Main()
+        {
+            Console.WriteLine(""Calling Console.WriteLine, a dependency on System namespace."");
+        }
+    }
+}
+";
+
+            string expected = @"
+using System.Runtime.InteropServices;
+using System;
+using System.IO;
+
+namespace N1
+{
+    public class Test
+    {
+        public static void Main()
+        {
+            Console.WriteLine(""Calling Console.WriteLine, a dependency on System namespace."");
+        }
+    }
+}
+";
+            Verify(input, expected, runFormatter: false);
+        }
+
+        [Fact]
+        public void PlaceImportsOutsideNamespace_Trivia()
+        {
+            string input = @"
+// Copyright Header
+
+namespace N1
+{
+    using System;
+    using System.IO; //Some comments
+
+    public class Test
+    {
+        public static void Main()
+        {
+            Console.WriteLine(""Calling Console.WriteLine, a dependency on System namespace."");
+        }
+    }
+}
+";
+
+            string expected = @"
+// Copyright Header
+
+using System;
+using System.IO; //Some comments
+
+namespace N1
+{
+    public class Test
+    {
+        public static void Main()
+        {
+            Console.WriteLine(""Calling Console.WriteLine, a dependency on System namespace."");
+        }
+    }
+}
+";
+            Verify(input, expected, runFormatter: false);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/AnalyzerIds.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/AnalyzerIds.cs
@@ -10,5 +10,6 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
         public const string OrderModifiers           = "DNS1002";
         public const string OptimizeNamespaceImports = "DNS1003";
         public const string ProvideExplicitVariableType     = "DNS1004";
+        public const string PlaceImportsOutsideNamespace = "DNS1005";
     }
 }

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/ExplicitThisAnalyzer.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/ExplicitThisAnalyzer.cs
@@ -23,7 +23,8 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
                                                                             ResourceHelper.MakeLocalizableString(nameof(Resources.ExplicitThisAnalyzer_MessageFormat)),
                                                                             "Style",
                                                                             DiagnosticSeverity.Warning,
-                                                                            true);
+                                                                            true,
+                                                                            customTags: RuleType.Local);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
             => ImmutableArray.Create(s_rule);

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/ExplicitThisAnalyzer.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/ExplicitThisAnalyzer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
                                                                             "Style",
                                                                             DiagnosticSeverity.Warning,
                                                                             true,
-                                                                            customTags: RuleType.Local);
+                                                                            customTags: RuleType.LocalSemantic);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
             => ImmutableArray.Create(s_rule);

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/Microsoft.DotNet.CodeFormatter.Analyzers.csproj
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/Microsoft.DotNet.CodeFormatter.Analyzers.csproj
@@ -77,6 +77,8 @@
     <Compile Include="OptimizeNamespaceImportsFixer.cs" />
     <Compile Include="OptimizeNamespaceImportsOptions.cs" />
     <Compile Include="OptionsHelper.cs" />
+    <Compile Include="PlaceImportsOutsideNamespaceAnalyzer.cs" />
+    <Compile Include="PlaceImportsOutsideNamespaceFixer.cs" />
     <Compile Include="Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/OptimizeNamespaceImportsAnalyzer.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/OptimizeNamespaceImportsAnalyzer.cs
@@ -19,12 +19,6 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class OptimizeNamespaceImportsAnalyzer : DiagnosticAnalyzer
     {
-        internal enum Action
-        {
-            Remove,
-            PlaceOutsideNamespace
-        }
-
         internal const string DiagnosticId = AnalyzerIds.OptimizeNamespaceImports;
         private static DiagnosticDescriptor s_rule = new DiagnosticDescriptor(DiagnosticId,
                                                                             ResourceHelper.MakeLocalizableString(nameof(Resources.OptimizeNamespaceImportsAnalyzer_Title)),
@@ -32,7 +26,7 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
                                                                             "Style",
                                                                             DiagnosticSeverity.Warning,
                                                                             true,
-                                                                            customTags: RuleType.Global);
+                                                                            customTags: RuleType.GlobalSemantic);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
             => ImmutableArray.Create(s_rule);
@@ -56,12 +50,6 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
                 {
                     context.RegisterSemanticModelAction(LookForUnusedImports);
                 }
-
-                if (properties.GetProperty(OptimizeNamespaceImportsOptions.PlaceImportsOutsideNamespaceDeclaration))
-                {
-                    context.RegisterSyntaxNodeAction(LookForUsingsInsideNamespace, SyntaxKind.NamespaceDeclaration);
-                }
-
             });
         }
 
@@ -93,19 +81,7 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
 
             if (locations.Count > 0)
             {
-                semanticModelAnalysisContext.ReportDiagnostic(
-                    Diagnostic.Create(s_rule, firstDiagnostic.Location, locations, 
-                                      new Dictionary<string, string> { { "Action", Action.Remove.ToString() } }.ToImmutableDictionary()));
-            }
-        }
-        private static void LookForUsingsInsideNamespace(SyntaxNodeAnalysisContext syntaxContext)
-        {
-            var namespaceDeclaration = syntaxContext.Node as NamespaceDeclarationSyntax;
-            if (namespaceDeclaration.Usings.Count != 0)
-            {
-                var allLocations = namespaceDeclaration.Usings.Select(d => d.GetLocation());
-                syntaxContext.ReportDiagnostic(Diagnostic.Create(s_rule, namespaceDeclaration.Usings.First().GetLocation(), allLocations,
-                                                                 new Dictionary<string, string> { { "Action", Action.PlaceOutsideNamespace.ToString() } }.ToImmutableDictionary()));
+                semanticModelAnalysisContext.ReportDiagnostic(Diagnostic.Create(s_rule, firstDiagnostic.Location, locations));
             }
         }
     }

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/OptimizeNamespaceImportsAnalyzer.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/OptimizeNamespaceImportsAnalyzer.cs
@@ -23,7 +23,8 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
                                                                             ResourceHelper.MakeLocalizableString(nameof(Resources.OptimizeNamespaceImportsAnalyzer_MessageFormat)),
                                                                             "Style",
                                                                             DiagnosticSeverity.Warning,
-                                                                            true);
+                                                                            true,
+                                                                            customTags: RuleType.Global);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
             => ImmutableArray.Create(s_rule);

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/OptimizeNamespaceImportsFixer.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/OptimizeNamespaceImportsFixer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -10,6 +11,8 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
 
 namespace Microsoft.DotNet.CodeFormatter.Analyzers
 {
@@ -19,30 +22,66 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-            Diagnostic diagnostic = context.Diagnostics.First();
-            var usingDirectiveNodes = new List<SyntaxNode>();
 
-            // We recapitulate the primary diagnostic location in the 
-            // Diagnostic.AdditionalLocations property on raising
-            // the diagnostic, so this member has complete location details.
-            foreach (Location location in diagnostic.AdditionalLocations)
+            foreach (var diagnostic in context.Diagnostics)
             {
-                SyntaxNode usingDirectiveNode = root.FindNode(location.SourceSpan);
-                Debug.Assert(usingDirectiveNode != null);
-                usingDirectiveNodes.Add(usingDirectiveNode);
-            }
+                var usingDirectiveNodes = new List<SyntaxNode>();
 
-            context.RegisterCodeFix(
-                CodeAction.Create(
-                    Resources.OptimizeNamespaceImportsFixer_Title,
-                    c => RemoveUsingStatement(context.Document, root, usingDirectiveNodes)),
-                diagnostic);
+                // We recapitulate the primary diagnostic location in the 
+                // Diagnostic.AdditionalLocations property on raising
+                // the diagnostic, so this member has complete location details.
+                foreach (Location location in diagnostic.AdditionalLocations)
+                {
+                    SyntaxNode usingDirectiveNode = root.FindNode(location.SourceSpan);
+                    Debug.Assert(usingDirectiveNode != null);
+                    usingDirectiveNodes.Add(usingDirectiveNode);
+                }
+
+                var usingAction = (OptimizeNamespaceImportsAnalyzer.Action)Enum.Parse(typeof(OptimizeNamespaceImportsAnalyzer.Action), diagnostic.Properties["Action"]);
+                switch (usingAction)
+                {
+                    case OptimizeNamespaceImportsAnalyzer.Action.Remove:
+                        context.RegisterCodeFix(
+                            CodeAction.Create(
+                                Resources.OptimizeNamespaceImportsFixer_Title,
+                                c => RemoveUsingStatement(context.Document, root, usingDirectiveNodes)),
+                            diagnostic);
+                        break;
+                    case OptimizeNamespaceImportsAnalyzer.Action.PlaceOutsideNamespace:
+                        context.RegisterCodeFix(
+                            CodeAction.Create(
+                                Resources.OptimizeNamespaceImportsFixer_Title,
+                                c => PlaceOutsideNamespace(context.Document, root, usingDirectiveNodes)),
+                            diagnostic);
+                        break;
+                }
+            }
         }
 
         private Task<Document> RemoveUsingStatement(Document document, SyntaxNode root, IEnumerable<SyntaxNode> usingDirectiveNodes)
         {     
             return Task.FromResult(
                 document.WithSyntaxRoot(root.RemoveNodes(usingDirectiveNodes, SyntaxRemoveOptions.KeepLeadingTrivia)));
+        }
+        private async Task<Document> PlaceOutsideNamespace(Document document, SyntaxNode root, IEnumerable<SyntaxNode> usingDirectiveNodes)
+        {
+            var semanticModel = await document.GetSemanticModelAsync().ConfigureAwait(false);
+            var editor = await DocumentEditor.CreateAsync(document).ConfigureAwait(false);
+
+            var newUsings = new List<SyntaxNode>();
+            foreach (var node in usingDirectiveNodes)
+            {
+                var usingDirective = node as UsingDirectiveSyntax;
+                var symbol = semanticModel.GetSymbolInfo(usingDirective.Name).Symbol;
+                var newDirective = editor.Generator.WithName(usingDirective, symbol.ToDisplayString());
+                editor.RemoveNode(usingDirective);
+                newUsings.Add(newDirective);
+            }
+
+            var newRoot = editor.GetChangedRoot();
+            newRoot = editor.Generator.AddNamespaceImports(newRoot, newUsings);
+            editor.ReplaceNode(root, newRoot);
+            return editor.GetChangedDocument();
         }
 
         public override FixAllProvider GetFixAllProvider()

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/OptimizeNamespaceImportsFixer.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/OptimizeNamespaceImportsFixer.cs
@@ -73,9 +73,12 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
             {
                 var usingDirective = node as UsingDirectiveSyntax;
                 var symbol = semanticModel.GetSymbolInfo(usingDirective.Name).Symbol;
-                var newDirective = editor.Generator.WithName(usingDirective, symbol.ToDisplayString());
-                editor.RemoveNode(usingDirective);
-                newUsings.Add(newDirective);
+                if (symbol != null)
+                {
+                    var newDirective = editor.Generator.WithName(usingDirective, symbol.ToDisplayString());
+                    editor.RemoveNode(usingDirective);
+                    newUsings.Add(newDirective);
+                }
             }
 
             var newRoot = editor.GetChangedRoot();

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/OptimizeNamespaceImportsOptions.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/OptimizeNamespaceImportsOptions.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
         /// <summary>
         /// Place import directives outside namespace declaration (or within if value is false).
         /// </summary>
-        public static PerLanguageOption<bool> PlaceImportsOutsideNamespaceDeclaration { get; } = new PerLanguageOption<bool>(OptimizeNamespaceImportsAnalyzer.AnalyzerName, nameof(PlaceImportsOutsideNamespaceDeclaration), defaultValue: true);
+        public static PerLanguageOption<bool> PlaceImportsOutsideNamespaceDeclaration { get; } = new PerLanguageOption<bool>(PlaceImportsOutsideNamespaceAnalyzer.AnalyzerName, nameof(PlaceImportsOutsideNamespaceDeclaration), defaultValue: true);
 
         /// <summary>
         /// Place system namespaces first when writing import directives.

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/PlaceImportsOutsideNamespaceAnalyzer.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/PlaceImportsOutsideNamespaceAnalyzer.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.DotNet.CodeFormatter.Analyzers
+{
+    [Export(typeof(DiagnosticAnalyzer))]
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class PlaceImportsOutsideNamespaceAnalyzer : DiagnosticAnalyzer
+    {
+        internal const string DiagnosticId = AnalyzerIds.PlaceImportsOutsideNamespace;
+        private static DiagnosticDescriptor s_rule = new DiagnosticDescriptor(DiagnosticId,
+                                                                            ResourceHelper.MakeLocalizableString(nameof(Resources.PlaceImportsOutsideNamespace_Title)),
+                                                                            ResourceHelper.MakeLocalizableString(nameof(Resources.PlaceImportsOutsideNamespace_MessageFormat)),
+                                                                            "Style",
+                                                                            DiagnosticSeverity.Warning,
+                                                                            true,
+                                                                            customTags: RuleType.LocalSemantic);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_rule);
+
+        public const string AnalyzerName = AnalyzerIds.PlaceImportsOutsideNamespace + "." + nameof(AnalyzerIds.PlaceImportsOutsideNamespace);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterCompilationStartAction(compilationContext =>
+            {
+                PropertyBag properties = OptionsHelper.GetProperties(compilationContext.Options);
+
+                if (!properties.GetProperty(OptionsHelper.BuildDefaultEnabledProperty(AnalyzerName)))
+                {
+                    // Analyzer is entirely disabled
+                    return;
+                }
+                
+                if (properties.GetProperty(OptimizeNamespaceImportsOptions.PlaceImportsOutsideNamespaceDeclaration))
+                {
+                    context.RegisterSyntaxNodeAction(LookForUsingsInsideNamespace, SyntaxKind.NamespaceDeclaration);
+                }
+            });
+        }
+
+        private static void LookForUsingsInsideNamespace(SyntaxNodeAnalysisContext syntaxContext)
+        {
+            var namespaceDeclaration = syntaxContext.Node as NamespaceDeclarationSyntax;
+            if (namespaceDeclaration.Usings.Count != 0)
+            {
+                var allLocations = namespaceDeclaration.Usings.Select(d => d.GetLocation());
+                syntaxContext.ReportDiagnostic(Diagnostic.Create(s_rule, namespaceDeclaration.Usings.First().GetLocation(), allLocations));
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/PlaceImportsOutsideNamespaceFixer.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/PlaceImportsOutsideNamespaceFixer.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
             foreach (Location location in diagnostic.AdditionalLocations)
             {
                 SyntaxNode usingDirectiveNode = root.FindNode(location.SourceSpan);
-                Debug.Assert(usingDirectiveNode != null);
+                Debug.Assert(usingDirectiveNode != null && usingDirectiveNode.IsKind(SyntaxKind.UsingDirective));
                 usingDirectiveNodes.Add(usingDirectiveNode);
             }
 

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/PlaceImportsOutsideNamespaceFixer.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/PlaceImportsOutsideNamespaceFixer.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Microsoft.DotNet.CodeFormatter.Analyzers
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp)]
+    class PlaceImportsOutsideNamespaceFixer : CodeFixProvider
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(PlaceImportsOutsideNamespaceAnalyzer.DiagnosticId);
+
+        public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+            var diagnostic = context.Diagnostics.First();
+            var usingDirectiveNodes = new List<SyntaxNode>();
+
+            // We recapitulate the primary diagnostic location in the 
+            // Diagnostic.AdditionalLocations property on raising
+            // the diagnostic, so this member has complete location details.
+            foreach (Location location in diagnostic.AdditionalLocations)
+            {
+                SyntaxNode usingDirectiveNode = root.FindNode(location.SourceSpan);
+                Debug.Assert(usingDirectiveNode != null);
+                usingDirectiveNodes.Add(usingDirectiveNode);
+            }
+
+            context.RegisterCodeFix(
+                        CodeAction.Create(
+                            Resources.OptimizeNamespaceImportsFixer_Title,
+                            c => PlaceOutsideNamespace(context.Document, root, usingDirectiveNodes)),
+                        diagnostic);
+        }
+
+        private async Task<Document> PlaceOutsideNamespace(Document document, SyntaxNode root, IEnumerable<SyntaxNode> usingDirectiveNodes)
+        {
+            var semanticModel = await document.GetSemanticModelAsync().ConfigureAwait(false);
+            var editor = await DocumentEditor.CreateAsync(document).ConfigureAwait(false);
+
+            var newUsings = new List<SyntaxNode>();
+            foreach (var node in usingDirectiveNodes)
+            {
+                var usingDirective = node as UsingDirectiveSyntax;
+                var symbol = semanticModel.GetSymbolInfo(usingDirective.Name).Symbol;
+                if (symbol != null)
+                {
+                    var newDirective = editor.Generator.WithName(usingDirective, symbol.ToDisplayString())
+                                       .WithAdditionalAnnotations(Formatter.Annotation)
+                                       .WithTriviaFrom(usingDirective);
+                    editor.RemoveNode(usingDirective);
+                    newUsings.Add(newDirective);
+                }
+            }
+
+
+            var newRoot = editor.GetChangedRoot();
+
+            if (newUsings.Any())
+            {
+                // Add a blank line to the last using statement so that it's demarcated from the rest of the code.
+                newUsings[newUsings.Count - 1] = AddBlankLine(newUsings.Last());
+
+                // If the usings are added to the top of the file, we need to attach the leading trivia to it. 
+                // To do that, store away the leading trivia from the root and re-attach it once the usings have been added.
+                var leadingTrivia = newRoot.GetLeadingTrivia();
+                newRoot = newRoot.WithoutLeadingTrivia();
+                newRoot = editor.Generator.AddNamespaceImports(newRoot, newUsings);
+                newRoot = newRoot.WithLeadingTrivia(leadingTrivia);
+            }
+
+            editor.ReplaceNode(root, newRoot);
+            return editor.GetChangedDocument();
+        }
+
+        private SyntaxNode AddBlankLine(SyntaxNode syntaxNode)
+        {
+            var trailingTrivia = syntaxNode.GetTrailingTrivia();
+            return syntaxNode.WithTrailingTrivia(trailingTrivia.Add(SyntaxFactory.ElasticCarriageReturnLineFeed));
+        }
+    }
+}

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/ProvideExplicitVariableTypeAnalyzer.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/ProvideExplicitVariableTypeAnalyzer.cs
@@ -30,14 +30,14 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
                                                                             "Style",
                                                                             DiagnosticSeverity.Warning,
                                                                             true,
-                                                                            customTags: new[] { VariableDeclarationCustomTag, RuleType.Local });
+                                                                            customTags: new[] { VariableDeclarationCustomTag, RuleType.LocalSemantic });
         private static readonly DiagnosticDescriptor s_ruleForEachStatement = new DiagnosticDescriptor(DiagnosticId,
                                                                             ResourceHelper.MakeLocalizableString(nameof(Resources.ExplicitVariableTypeAnalyzer_Title)),
                                                                             ResourceHelper.MakeLocalizableString(nameof(Resources.ExplicitVariableTypeAnalyzer_MessageFormat)),
                                                                             "Style",
                                                                             DiagnosticSeverity.Warning,
                                                                             true,
-                                                                            customTags: new[] { ForEachStatementCustomTag, RuleType.Local });
+                                                                            customTags: new[] { ForEachStatementCustomTag, RuleType.LocalSemantic });
 
         private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedRules = ImmutableArray.Create(s_ruleVariableDeclaration, s_ruleForEachStatement);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/ProvideExplicitVariableTypeAnalyzer.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/ProvideExplicitVariableTypeAnalyzer.cs
@@ -30,14 +30,14 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
                                                                             "Style",
                                                                             DiagnosticSeverity.Warning,
                                                                             true,
-                                                                            customTags: VariableDeclarationCustomTag);
+                                                                            customTags: new[] { VariableDeclarationCustomTag, RuleType.Local });
         private static readonly DiagnosticDescriptor s_ruleForEachStatement = new DiagnosticDescriptor(DiagnosticId,
                                                                             ResourceHelper.MakeLocalizableString(nameof(Resources.ExplicitVariableTypeAnalyzer_Title)),
                                                                             ResourceHelper.MakeLocalizableString(nameof(Resources.ExplicitVariableTypeAnalyzer_MessageFormat)),
                                                                             "Style",
                                                                             DiagnosticSeverity.Warning,
                                                                             true,
-                                                                            customTags: ForEachStatementCustomTag);
+                                                                            customTags: new[] { ForEachStatementCustomTag, RuleType.Local });
 
         private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedRules = ImmutableArray.Create(s_ruleVariableDeclaration, s_ruleForEachStatement);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/ProvideExplicitVariableTypeFixer.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/ProvideExplicitVariableTypeFixer.cs
@@ -80,7 +80,9 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
         private async Task<Document> ReplaceVarWithExplicitType(Document document, SyntaxNode varNode, ITypeSymbol explicitTypeSymbol, CancellationToken cancellationToken)
         {
             DocumentEditor documentEditor = await DocumentEditor.CreateAsync(document, cancellationToken);
-            SyntaxNode explicitTypeNode = documentEditor.Generator.TypeExpression(explicitTypeSymbol).WithAdditionalAnnotations(Simplifier.Annotation);
+            SyntaxNode explicitTypeNode = documentEditor.Generator.TypeExpression(explicitTypeSymbol)
+                                          .WithAdditionalAnnotations(Simplifier.Annotation)
+                                          .WithTriviaFrom(varNode);
             documentEditor.ReplaceNode(varNode, explicitTypeNode);
             return documentEditor.GetChangedDocument();
         }

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/Resources.Designer.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/Resources.Designer.cs
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Variable &apos;{0}&apos; should be declared with explicit type.
+        ///   Looks up a localized string similar to Variable &apos;{0}&apos; should be declared with an explicit type.
         /// </summary>
         internal static string ExplicitVariableTypeAnalyzer_MessageFormat {
             get {
@@ -106,7 +106,7 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Replace the usage of &apos;var&apos; with explicit type.
+        ///   Looks up a localized string similar to Replace the usage of &apos;var&apos; with an explicit type.
         /// </summary>
         internal static string ExplicitVariableTypeFixer_Title {
             get {
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove unused namespaces.
+        ///   Looks up a localized string similar to Namespace &apos;{0}&apos; is unused in this file.
         /// </summary>
         internal static string OptimizeNamespaceImportsAnalyzer_MessageFormat {
             get {
@@ -124,7 +124,7 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Namespace &apos;{0}&apos; is unused in this file.
+        ///   Looks up a localized string similar to Remove unused namespace imports.
         /// </summary>
         internal static string OptimizeNamespaceImportsAnalyzer_Title {
             get {
@@ -133,11 +133,38 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove unused namespaces.
+        ///   Looks up a localized string similar to Remove unused namespace imports.
         /// </summary>
         internal static string OptimizeNamespaceImportsFixer_Title {
             get {
                 return ResourceManager.GetString("OptimizeNamespaceImportsFixer_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Place namespace import statements outside a namespace..
+        /// </summary>
+        internal static string PlaceImportsOutsideNamespace_MessageFormat {
+            get {
+                return ResourceManager.GetString("PlaceImportsOutsideNamespace_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Place namespace import statements outside a namespace..
+        /// </summary>
+        internal static string PlaceImportsOutsideNamespace_Title {
+            get {
+                return ResourceManager.GetString("PlaceImportsOutsideNamespace_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Move import statements outside the namespace..
+        /// </summary>
+        internal static string PlaceImportsOutsideNamespaceFixer_Title {
+            get {
+                return ResourceManager.GetString("PlaceImportsOutsideNamespaceFixer_Title", resourceCulture);
             }
         }
         

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/Resources.resx
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/Resources.resx
@@ -136,13 +136,22 @@
     <value>Replace the usage of 'var' with an explicit type</value>
   </data>
   <data name="OptimizeNamespaceImportsAnalyzer_MessageFormat" xml:space="preserve">
-    <value>Remove unused namespaces</value>
-  </data>
-  <data name="OptimizeNamespaceImportsAnalyzer_Title" xml:space="preserve">
     <value>Namespace '{0}' is unused in this file</value>
   </data>
+  <data name="OptimizeNamespaceImportsAnalyzer_Title" xml:space="preserve">
+    <value>Remove unused namespace imports</value>
+  </data>
   <data name="OptimizeNamespaceImportsFixer_Title" xml:space="preserve">
-    <value>Remove unused namespaces</value>
+    <value>Remove unused namespace imports</value>
+  </data>
+  <data name="PlaceImportsOutsideNamespaceFixer_Title" xml:space="preserve">
+    <value>Move import statements outside the namespace.</value>
+  </data>
+  <data name="PlaceImportsOutsideNamespace_MessageFormat" xml:space="preserve">
+    <value>Place namespace import statements outside a namespace.</value>
+  </data>
+  <data name="PlaceImportsOutsideNamespace_Title" xml:space="preserve">
+    <value>Place namespace import statements outside a namespace.</value>
   </data>
   <data name="UnwrittenWritableFieldAnalyzer_MessageFormat" xml:space="preserve">
     <value>The field '{0}' is never written to and can be marked readonly</value>

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/UnwrittenWritableFieldAnalyzer.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/UnwrittenWritableFieldAnalyzer.cs
@@ -27,7 +27,8 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
                                                                             ResourceHelper.MakeLocalizableString(nameof(Resources.UnwrittenWritableFieldAnalyzer_MessageFormat)),
                                                                             "Usage",
                                                                             DiagnosticSeverity.Warning,
-                                                                            true);
+                                                                            true,
+                                                                            customTags: RuleType.Local);
 
         private static readonly SyntaxKind[] s_compoundAssignmentExpressionKinds =
             {

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/UnwrittenWritableFieldAnalyzer.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/UnwrittenWritableFieldAnalyzer.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
                                                                             "Usage",
                                                                             DiagnosticSeverity.Warning,
                                                                             true,
-                                                                            customTags: RuleType.Local);
+                                                                            customTags: RuleType.LocalSemantic);
 
         private static readonly SyntaxKind[] s_compoundAssignmentExpressionKinds =
             {

--- a/src/Microsoft.DotNet.CodeFormatting/FormattingEngineImplementation.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/FormattingEngineImplementation.cs
@@ -365,18 +365,21 @@ namespace Microsoft.DotNet.CodeFormatting
                 if (compilerDiagnostics.Any())
                 {
 
-                        Console.WriteLine("Error count " + compilerDiagnostics.Count());
+                    Console.WriteLine("Error count " + compilerDiagnostics.Count());
 
-                        Console.WriteLine("Metadata References for {0}", project.Name);
-                        foreach (var mr in project.MetadataReferences)
-                        {
-                            Console.WriteLine(mr.Display);
-                        }
+                    Console.WriteLine("Metadata References for {0}", project.Name);
+                    foreach (var mr in project.MetadataReferences)
+                    {
+                        Console.WriteLine(mr.Display);
+                    }
 
-                        foreach (var diag in compilerDiagnostics)
-                        {
-                            Console.WriteLine(diag.ToString());
-                        }
+                    Console.WriteLine();
+                    Console.WriteLine("Diagnostics for {0}", project.Name);
+
+                    foreach (var diag in compilerDiagnostics)
+                    {
+                        Console.WriteLine(diag.ToString());
+                    }
                 }
             }
 

--- a/src/Microsoft.DotNet.CodeFormatting/Microsoft.DotNet.CodeFormatting.csproj
+++ b/src/Microsoft.DotNet.CodeFormatting/Microsoft.DotNet.CodeFormatting.csproj
@@ -78,6 +78,7 @@
     <Compile Include="ResponseFileWorkspace.cs" />
     <Compile Include="Rules\MarkReadonlyFieldsRule.cs" />
     <Compile Include="Rules\RuleOptions.cs" />
+    <Compile Include="RuleType.cs" />
     <Compile Include="SemaphoreLock.cs" />
     <Compile Include="SyntaxUtil.cs" />
     <Compile Include="Filters\FilenameFilter.cs" />

--- a/src/Microsoft.DotNet.CodeFormatting/RuleType.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/RuleType.cs
@@ -2,7 +2,23 @@
 {
     public static class RuleType
     {
-        public const string Local = nameof(Local);
-        public const string Global = nameof(Global);
+        /// <summary>
+        /// This type of rule is a purely syntactic rule and doesn't need any semantic information to analyze or fix the issue.
+        /// Such rules can be correct in a broken compilation as well.
+        /// </summary>
+        public const string Syntactic = nameof(Syntactic);
+
+        /// <summary>
+        /// This type of rule needs to look at semantic information to either diagnose or fix the issue. The semantic information
+        /// is localized the site of the issue and any fix will only semantically affect the site of the issue or the enclosing code block 
+        /// for eg: an edit inside a method body.
+        /// </summary>
+        public const string LocalSemantic = nameof(LocalSemantic);
+
+        /// <summary>
+        /// This type of rule needs to look at semantic information to either diagnose or fix the issue. A fix for the rule cause a 
+        /// global semantic change.
+        /// </summary>
+        public const string GlobalSemantic = nameof(GlobalSemantic);
     }
 }

--- a/src/Microsoft.DotNet.CodeFormatting/RuleType.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/RuleType.cs
@@ -11,7 +11,7 @@
         /// <summary>
         /// This type of rule needs to look at semantic information to either diagnose or fix the issue. The semantic information
         /// is localized the site of the issue and any fix will only semantically affect the site of the issue or the enclosing code block 
-        /// for eg: an edit inside a method body.
+        /// for example: an edit inside a method body.
         /// </summary>
         public const string LocalSemantic = nameof(LocalSemantic);
 

--- a/src/Microsoft.DotNet.CodeFormatting/RuleType.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/RuleType.cs
@@ -1,0 +1,8 @@
+﻿namespace Microsoft.DotNet.CodeFormatter.Analyzers
+{
+    public static class RuleType
+    {
+        public const string Local = nameof(Local);
+        public const string Global = nameof(Global);
+    }
+}


### PR DESCRIPTION
Introduce the concept of local and global rules for analyzers such that all local fixes can be applied together whereas global rules will have to be applied one by one. 

This is necessary to fix an issue where the remove unused using fixer was removing an using that only became necessary by the "Make type explicit" fixer and they cannot be applied together.

This PR also implements the rule about placing usings outside the namespace as analyzers\fixers. The original rule in the Rules directory tries to simply move the using syntactically but that is incorrect. If there's using A inside namespace B then when moved out it might have to using B.A and so we need semantics. Fixing that in the analyzer and adding tests.