### PR TITLE
Fixing a bug in the Provide Explicit type rule where it was trying to…

### DIFF
--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers.Tests/ProvideExplicitVariableTypeAnalyzerTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers.Tests/ProvideExplicitVariableTypeAnalyzerTests.cs
@@ -300,6 +300,47 @@ class C1
         }
 
         [Fact]
+        public void TestDeclarationWithAnonymousTypeArguments()
+        {
+            const string input = @"
+using System.Linq;
+
+class C1
+{
+    void M()
+    {
+        var names = from i in new [] { 1, 2, 3 }
+                    select new { Number = i, Age = i };
+
+        foreach (var name in names)
+        { }
+    }
+}";
+            const string expected = input;
+            Verify(input, expected, runFormatter: false);
+        }
+
+        [Fact]
+        public void TestForEachWithErrorType()
+        {
+            const string input = @"
+class C1
+{
+    void M()
+    {
+        // names will have error type here because System.Linq isn't included.
+        var names = from i in new [] { 1, 2, 3 }
+                    select new { Number = i, Age = i };
+
+        foreach (var name in names)
+        { }
+    }
+}";
+            const string expected = input;
+            Verify(input, expected, runFormatter: false);
+        }
+
+        [Fact]
         public void TestVarDeclarationInUsing()
         {
             const string input = @"

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers.Tests/ProvideExplicitVariableTypeAnalyzerTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers.Tests/ProvideExplicitVariableTypeAnalyzerTests.cs
@@ -309,6 +309,8 @@ class C1
 {
     void M()
     {
+        // The variable names if of type IEnumerable<some_anonymous_type>. It is not itself of anonymous type,
+        // but it has a type parameter of anonymous type.
         var names = from i in new [] { 1, 2, 3 }
                     select new { Number = i, Age = i };
 

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/ProvideExplicitVariableTypeAnalyzer.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/ProvideExplicitVariableTypeAnalyzer.cs
@@ -84,7 +84,7 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
                     node.Type.IsVar &&
                     !IsTypeObvious(node) &&
                     !IsAnonymousType(node, model, token)&&
-                    !HasErrors(node.Expression, model, token))
+                    !HasErrors(node, model, token))
                 {
                     syntaxContext.ReportDiagnostic(Diagnostic.Create(s_ruleForEachStatement, node.Identifier.GetLocation(), node.Identifier.Text));
                 }
@@ -112,8 +112,11 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
         private static bool IsAnonymousType(SyntaxNode node, SemanticModel model, CancellationToken cancellationToken)
         {
             ISymbol symbol = model.GetDeclaredSymbol(node, cancellationToken);
-            bool? isAnonymousType = ((ILocalSymbol)symbol)?.Type?.IsAnonymousType;
-            return isAnonymousType.HasValue && isAnonymousType.Value;
+            ITypeSymbol type = ((ILocalSymbol)symbol)?.Type;
+            bool? isAnonymousType = type?.IsAnonymousType;
+            bool? containsAnonymousTypeArguments = (type as INamedTypeSymbol)?.TypeArguments.Any(t => t.IsAnonymousType);
+            return (isAnonymousType.HasValue && isAnonymousType.Value) ||
+                   (containsAnonymousTypeArguments.HasValue && containsAnonymousTypeArguments.Value);
         }
 
         /// <summary>


### PR DESCRIPTION
… make a generic type with anonymous type parameters explicit.

There was also a case where if a foreach statement had an error type, we weren't bailing out correctly.

@lgolding @genlu @mavasani 