### PR TITLE
The rule that makes types explicit should add a using when it needs to qualify type.

### DIFF
--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers.Tests/ProvideExplicitVariableTypeAnalyzerTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers.Tests/ProvideExplicitVariableTypeAnalyzerTests.cs
@@ -32,7 +32,7 @@ class C1
         int[][] z = new[] { new[] { 1, 2, 3 }, new[] { 4, 5, 6 } };
     }
 }";
-            const string expected = input; 
+            const string expected = input;
             Verify(input, expected, runFormatter: false);
         }
 
@@ -510,6 +510,64 @@ class C1
     {
         List<int>.Enumerator x = (new List<int>()).GetEnumerator();
         var locationBuilder = ImmutableArray.CreateBuilder<C2>();
+    }
+}";
+            Verify(input, expected, runFormatter: false);
+        }
+
+        [Fact]
+        public void TestAddingUsing()
+        {
+            const string input = @"
+class C1
+{
+    System.Collections.Generic.List<int> f() { return null; }
+
+    void M()
+    {
+        var x = f();
+    }
+}";
+            const string expected =
+@"using System.Collections.Generic;
+
+class C1
+{
+    System.Collections.Generic.List<int> f() { return null; }
+
+    void M()
+    {
+        List<int> x = f();
+    }
+}";
+            Verify(input, expected, runFormatter: false);
+        }
+
+        [Fact]
+        public void TestNotAddingDuplicateUsing()
+        {
+            const string input = @"
+using System.Collections.Generic;
+
+class C1
+{
+    System.Collections.Generic.List<int> f() { return null; }
+
+    void M()
+    {
+        var x = f();
+    }
+}";
+            const string expected = @"
+using System.Collections.Generic;
+
+class C1
+{
+    System.Collections.Generic.List<int> f() { return null; }
+
+    void M()
+    {
+        List<int> x = f();
     }
 }";
             Verify(input, expected, runFormatter: false);

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/ProvideExplicitVariableTypeFixer.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/ProvideExplicitVariableTypeFixer.cs
@@ -84,7 +84,15 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
                                           .WithAdditionalAnnotations(Simplifier.Annotation)
                                           .WithTriviaFrom(varNode);
             documentEditor.ReplaceNode(varNode, explicitTypeNode);
-            return documentEditor.GetChangedDocument();
+            var newDocument = documentEditor.GetChangedDocument();
+
+            // We don't want the explicit type to be fully qualified. So add an using for this node and the simplifier will
+            // take care of removing it if it isn't necessary.
+            // The second parmaeter to AddImportsAsync is an annotation that is used to locate the span
+            // for which an using should be added. Since we added the simplify annotation on explicitTypeNode, 
+            // we can just use that annotation to locate the node again in newDocument. 
+            newDocument = await ImportAdder.AddImportsAsync(newDocument, Simplifier.Annotation).ConfigureAwait(false);
+            return newDocument;
         }
 
         private static RuleType GetRuleType(Diagnostic diagnostic)


### PR DESCRIPTION
If there's code that's being converted from var to an explicit type and there's no using for that type in the file, the fix should add the using instead of generating a fully qualified name.

@lgolding @genlu @mavasani 