### PR TITLE
Revert "The rule that makes types explicit should add a using when it needs to qualify type."

### DIFF
--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers.Tests/ProvideExplicitVariableTypeAnalyzerTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers.Tests/ProvideExplicitVariableTypeAnalyzerTests.cs
@@ -32,7 +32,7 @@ class C1
         int[][] z = new[] { new[] { 1, 2, 3 }, new[] { 4, 5, 6 } };
     }
 }";
-            const string expected = input;
+            const string expected = input; 
             Verify(input, expected, runFormatter: false);
         }
 
@@ -510,64 +510,6 @@ class C1
     {
         List<int>.Enumerator x = (new List<int>()).GetEnumerator();
         var locationBuilder = ImmutableArray.CreateBuilder<C2>();
-    }
-}";
-            Verify(input, expected, runFormatter: false);
-        }
-
-        [Fact]
-        public void TestAddingUsing()
-        {
-            const string input = @"
-class C1
-{
-    System.Collections.Generic.List<int> f() { return null; }
-
-    void M()
-    {
-        var x = f();
-    }
-}";
-            const string expected =
-@"using System.Collections.Generic;
-
-class C1
-{
-    System.Collections.Generic.List<int> f() { return null; }
-
-    void M()
-    {
-        List<int> x = f();
-    }
-}";
-            Verify(input, expected, runFormatter: false);
-        }
-
-        [Fact]
-        public void TestNotAddingDuplicateUsing()
-        {
-            const string input = @"
-using System.Collections.Generic;
-
-class C1
-{
-    System.Collections.Generic.List<int> f() { return null; }
-
-    void M()
-    {
-        var x = f();
-    }
-}";
-            const string expected = @"
-using System.Collections.Generic;
-
-class C1
-{
-    System.Collections.Generic.List<int> f() { return null; }
-
-    void M()
-    {
-        List<int> x = f();
     }
 }";
             Verify(input, expected, runFormatter: false);

--- a/src/Microsoft.DotNet.CodeFormatter.Analyzers/ProvideExplicitVariableTypeFixer.cs
+++ b/src/Microsoft.DotNet.CodeFormatter.Analyzers/ProvideExplicitVariableTypeFixer.cs
@@ -80,21 +80,11 @@ namespace Microsoft.DotNet.CodeFormatter.Analyzers
         private async Task<Document> ReplaceVarWithExplicitType(Document document, SyntaxNode varNode, ITypeSymbol explicitTypeSymbol, CancellationToken cancellationToken)
         {
             DocumentEditor documentEditor = await DocumentEditor.CreateAsync(document, cancellationToken);
-
-            // Create an annotation and tag the type node with it so that we can find it again in a new tree.
-            var explicitTypeAnnotation = new SyntaxAnnotation();
             SyntaxNode explicitTypeNode = documentEditor.Generator.TypeExpression(explicitTypeSymbol)
-                                          .WithAdditionalAnnotations(Simplifier.Annotation, explicitTypeAnnotation)
+                                          .WithAdditionalAnnotations(Simplifier.Annotation)
                                           .WithTriviaFrom(varNode);
             documentEditor.ReplaceNode(varNode, explicitTypeNode);
-            var newDocument = documentEditor.GetChangedDocument();
-
-            // We don't want the explicit type to be fully qualified. So add an using for this node and the simplifier will
-            // take care of removing it if it isn't necessary.
-            // The second parmaeter to AddImportsAsync is an annotation that is used to locate the span
-            // for which an using should be added.
-            newDocument = await ImportAdder.AddImportsAsync(newDocument, explicitTypeAnnotation).ConfigureAwait(false);
-            return newDocument;
+            return documentEditor.GetChangedDocument();
         }
 
         private static RuleType GetRuleType(Diagnostic diagnostic)


### PR DESCRIPTION
Reverts dotnet/codeformatter#210

It turns out that ImportAdder API in Roslyn has a bug where it doesn't check if adding the using causes any ambiguity errors. This causes this rule to break code. So reverting this change until the Roslyn bug can be addressed.