### PR TITLE
Support for /help and better error for unrecognized switches

### DIFF
--- a/src/CodeFormatter/CommandLineParser.cs
+++ b/src/CodeFormatter/CommandLineParser.cs
@@ -245,6 +245,10 @@ Use ConvertTests to convert MSTest tests to xUnit.
                 {
                     return CommandLineParseResult.CreateSuccess(CommandLineOptions.ListRules);
                 }
+                else if (arg.StartsWith("/", comparison))
+                {
+                    return CommandLineParseResult.CreateError($"Unrecognized option \"{arg}\"");
+                }
                 else
                 {
                     formatTargets.Add(arg);

--- a/src/CodeFormatter/CommandLineParser.cs
+++ b/src/CodeFormatter/CommandLineParser.cs
@@ -15,6 +15,7 @@ namespace CodeFormatter
     {
         Format,
         ListRules,
+        ShowHelp
     }
 
     public sealed class CommandLineOptions
@@ -29,6 +30,18 @@ namespace CodeFormatter
             null,
             allowTables: false,
             verbose: false);
+
+        public static readonly CommandLineOptions ShowHelp = new CommandLineOptions(
+            Operation.ShowHelp,
+            ImmutableArray<string[]>.Empty,
+            ImmutableArray<string>.Empty,
+            ImmutableDictionary<string, bool>.Empty,
+            ImmutableArray<string>.Empty,
+            ImmutableArray<string>.Empty,
+            null,
+            allowTables: false,
+            verbose: false);
+
 
         public readonly Operation Operation;
         public readonly ImmutableArray<string[]> PreprocessorConfigurations;
@@ -143,8 +156,7 @@ namespace CodeFormatter
     /rule(+|-)      - Enable (default) or disable the specified rule
     /rules          - List the available rules
     /verbose        - Verbose output
-
-Use ConvertTests to convert MSTest tests to xUnit.
+    /help           - Displays this usage message (short form: /?)
 ";
 
         public static void PrintUsage()
@@ -244,6 +256,10 @@ Use ConvertTests to convert MSTest tests to xUnit.
                 else if (comparer.Equals(arg, "/rules"))
                 {
                     return CommandLineParseResult.CreateSuccess(CommandLineOptions.ListRules);
+                }
+                else if (comparer.Equals(arg, "/?") || comparer.Equals(arg, "/help"))
+                {
+                    return CommandLineParseResult.CreateSuccess(CommandLineOptions.ShowHelp);
                 }
                 else if (arg.StartsWith("/", comparison))
                 {

--- a/src/CodeFormatter/Program.cs
+++ b/src/CodeFormatter/Program.cs
@@ -31,6 +31,11 @@ namespace CodeFormatter
             int exitCode;
             switch (options.Operation)
             {
+                case Operation.ShowHelp:
+                    CommandLineParser.PrintUsage();
+                    exitCode = 0;
+                    break;
+
                 case Operation.ListRules:
                     RunListRules();
                     exitCode = 0;

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/CommandLineParserTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/CommandLineParserTests.cs
@@ -17,6 +17,15 @@ namespace Microsoft.DotNet.CodeFormatting.Tests
             return options;
         }
 
+        private CommandLineOptions FailToParse(params string[] args)
+        {
+            CommandLineOptions options;
+            Assert.False(CommandLineParser.TryParse(args, out options));
+            Assert.Null(options);
+
+            return options;
+        }
+
         [Fact]
         public void Rules()
         {
@@ -113,6 +122,24 @@ namespace Microsoft.DotNet.CodeFormatting.Tests
             var options = Parse("/copyright", "test.csproj");
             Assert.True(options.RuleMap[FormattingDefaults.CopyrightRuleName]);
             Assert.Equal(new[] { "test.csproj" }, options.FormatTargets);
+        }
+
+        [Fact]
+        public void SingleUnrecognizedOption()
+        {
+            FailToParse("/unrecognized");
+        }
+
+        [Fact]
+        public void UnrecognizedOptionWithFormatTarget()
+        {
+            FailToParse("test.csproj", "/unrecognized");
+        }
+
+        [Fact]
+        public void UnrecognizedOptionWithOtherwiseValidArguments()
+        {
+            FailToParse("test.csproj", "/nocopyright", "/unrecognized");
         }
     }
 }

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/CommandLineParserTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/CommandLineParserTests.cs
@@ -108,6 +108,28 @@ namespace Microsoft.DotNet.CodeFormatting.Tests
             Assert.Equal(new[] { "test.csproj" }, options.FormatTargets);
         }
 
+
+        [Fact]
+        public void Help()
+        {
+            var options = Parse("/help");
+            Assert.Equal(options.Operation, Operation.ShowHelp);
+        }
+
+        [Fact]
+        public void HelpShortForm()
+        {
+            var options = Parse("/?");
+            Assert.Equal(options.Operation, Operation.ShowHelp);
+        }
+
+        [Fact]
+        public void HelpWithOtherwiseValidArguments()
+        {
+            var options = Parse("test.csproj", "/nocopyright", "/help");
+            Assert.Equal(options.Operation, Operation.ShowHelp);
+        }
+
         [Fact]
         public void CopyrightEnable1()
         {


### PR DESCRIPTION
Ran into these both using the tool.

Might be easier to read both commits separately.  