### PR TITLE
Turned copyright header off by default

### DIFF
--- a/src/CodeFormatter/CommandLineParser.cs
+++ b/src/CodeFormatter/CommandLineParser.cs
@@ -194,13 +194,13 @@ namespace CodeFormatter
                         return CommandLineParseResult.CreateError(error);
                     }
                 }
-                else if (arg.StartsWith(LanguageSwitch, comparison))
-                {
-                    language = arg.Substring(LanguageSwitch.Length);
-                }
                 else if (comparer.Equals(arg, "/nocopyright"))
                 {
                     ruleMap = ruleMap.SetItem(FormattingDefaults.CopyrightRuleName, false);
+                }
+                else if (arg.StartsWith(LanguageSwitch, comparison))
+                {
+                    language = arg.Substring(LanguageSwitch.Length);
                 }
                 else if (comparer.Equals(arg, "/nounicode"))
                 {

--- a/src/CodeFormatter/CommandLineParser.cs
+++ b/src/CodeFormatter/CommandLineParser.cs
@@ -172,13 +172,13 @@ namespace CodeFormatter
             for (int i = 0; i < args.Length; i++)
             {
                 string arg = args[i];
-                if (arg.StartsWith(ConfigSwitch, StringComparison.OrdinalIgnoreCase))
+                if (arg.StartsWith(ConfigSwitch, comparison))
                 {
                     var all = arg.Substring(ConfigSwitch.Length);
                     var configs = all.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
                     configBuilder.Add(configs);
                 }
-                else if (arg.StartsWith(CopyrightSwitch, StringComparison.OrdinalIgnoreCase))
+                else if (arg.StartsWith(CopyrightSwitch, comparison))
                 {
                     var fileName = arg.Substring(CopyrightSwitch.Length);
                     try
@@ -194,7 +194,7 @@ namespace CodeFormatter
                         return CommandLineParseResult.CreateError(error);
                     }
                 }
-                else if (arg.StartsWith(LanguageSwitch, StringComparison.OrdinalIgnoreCase))
+                else if (arg.StartsWith(LanguageSwitch, comparison))
                 {
                     language = arg.Substring(LanguageSwitch.Length);
                 }

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/CommandLineParserTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/CommandLineParserTests.cs
@@ -84,10 +84,34 @@ namespace Microsoft.DotNet.CodeFormatting.Tests
         }
 
         [Fact]
+        public void CopyrightDisable()
+        {
+            var options = Parse("/copyright-", "test.csproj");
+            Assert.False(options.RuleMap[FormattingDefaults.CopyrightRuleName]);
+            Assert.Equal(new[] { "test.csproj" }, options.FormatTargets);
+        }
+
+        [Fact]
         public void NoCopyright()
         {
             var options = Parse("/nocopyright", "test.csproj");
             Assert.False(options.RuleMap[FormattingDefaults.CopyrightRuleName]);
+            Assert.Equal(new[] { "test.csproj" }, options.FormatTargets);
+        }
+
+        [Fact]
+        public void CopyrightEnable1()
+        {
+            var options = Parse("/copyright+", "test.csproj");
+            Assert.True(options.RuleMap[FormattingDefaults.CopyrightRuleName]);
+            Assert.Equal(new[] { "test.csproj" }, options.FormatTargets);
+        }
+
+        [Fact]
+        public void CopyrightEnable2()
+        {
+            var options = Parse("/copyright", "test.csproj");
+            Assert.True(options.RuleMap[FormattingDefaults.CopyrightRuleName]);
             Assert.Equal(new[] { "test.csproj" }, options.FormatTargets);
         }
     }

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/CombinationTest.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/CombinationTest.cs
@@ -66,8 +66,7 @@ class C {
     }
 }";
 
-            var expected = @"// header
-
+            var expected = @"
 internal class C
 {
     private int _field;
@@ -123,8 +122,7 @@ class C {
     }
 }";
 
-            var expected = @"// header
-
+            var expected = @"
 internal class C
 {
     private int field;
@@ -151,8 +149,7 @@ class C {
     }
 }";
 
-            var expected = @"// header
-
+            var expected = @"
 internal class C
 {
     private int _field;
@@ -177,8 +174,7 @@ class C
 #endif 
 }";
 
-            var expected = @"// header
-
+            var expected = @"
 internal class C
 {
 #if DOG
@@ -201,8 +197,7 @@ internal class C
 #endif 
 }";
 
-            var expected = @"// header
-
+            var expected = @"
 internal class C
 {
 #if DOG
@@ -232,8 +227,7 @@ class C
 #endif 
 }";
 
-            var expected = @"// header
-
+            var expected = @"
 internal class C
 {
     private void G()
@@ -270,8 +264,7 @@ class C
 #endif 
 }";
 
-            var expected = @"// header
-
+            var expected = @"
 internal class C
 {
 #if TEST
@@ -310,8 +303,7 @@ internal class C
     }
 }";
 
-            var expected = @"// header
-
+            var expected = @"
 internal class C
 {
     private void M()
@@ -348,8 +340,7 @@ namespace Microsoft.Build.UnitTests
        {}
     }
 }";
-            var expected = @"// header
-
+            var expected = @"
 using System;
 using System.Reflection;
 

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.cs
@@ -13,7 +13,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {
-    [SyntaxRule(CopyrightHeaderRule.Name, CopyrightHeaderRule.Description, SyntaxRuleOrder.CopyrightHeaderRule)]
+    [SyntaxRule(CopyrightHeaderRule.Name, CopyrightHeaderRule.Description, SyntaxRuleOrder.CopyrightHeaderRule, DefaultRule=false)]
     internal sealed partial class CopyrightHeaderRule : SyntaxFormattingRule, ISyntaxFormattingRule
     {
         internal const string Name = FormattingDefaults.CopyrightRuleName;


### PR DESCRIPTION
Fixes: #151.

Before my change there were two options, specifying `/nocopyright`, or specifying `/copyright:foo.txt`. If we switched the header off by default, there was no way to opt into the default, therefore, I added enable/disable options to the copyright switch similar to /rule:

To turn on default copyright, you do:

```
codeformatter test.proj /copyright
codeformatter test.proj /copyright+
```

To turn off default copyright, you do:

```
codeformatter test.proj
codeformatter test.proj /copyright-
codeformatter test.proj /nocopyright (for backwards compat - not doc'd)
```

And like before you can specify a file:
```
codeformatter test.proj /copyright:copyright.txt
```