### PR TITLE
Handle removing "ts_" prefix from fields

### DIFF
--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/PrivateFieldNamingRuleTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/PrivateFieldNamingRuleTests.cs
@@ -331,6 +331,30 @@ End Class";
 
                 Verify(text, expected, languageName: LanguageNames.VisualBasic);
             }
+
+            [Fact]
+            public void RemoveTwoLetterThreadStaticPrefix()
+            {
+                var text = @"
+class C
+{
+    int ts_instance;
+    static int ts_Static;
+    [System.ThreadStatic]static int ts_ThreadStatic;
+}
+";
+
+                var expected = @"
+class C
+{
+    int _instance;
+    static int s_static;
+    [System.ThreadStatic]static int t_threadStatic;
+}
+";
+
+                Verify(text, expected, runFormatter: false);
+            }
         }
     }
 }

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/PrivateFieldNamingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/PrivateFieldNamingRule.cs
@@ -90,6 +90,12 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
                     name = name.Substring(2);
                 }
 
+                // Some .NET code uses "ts_" prefix for thread static
+                if (name.Length > 3 && name.StartsWith("ts_", StringComparison.OrdinalIgnoreCase))
+                {
+                    name = name.Substring(3);
+                }
+
                 if (name.Length == 0)
                 {
                     return fieldSymbol.Name;


### PR DESCRIPTION
Some .NET code that I ported uses the "ts_" prefix for thread static, added support for removing it.