### PR TITLE
Fixed default visibility of VB delegates

### DIFF
--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/ExplicitVisibilityRuleTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/ExplicitVisibilityRuleTests.cs
@@ -863,6 +863,29 @@ End Interface";
                 Verify(text, expected, runFormatter: false, languageName: LanguageNames.VisualBasic);
             }
 
+            [Fact]
+            public void Delegates()
+            {
+                var text = @"
+Delegate Function Func1() As Boolean
+
+Friend Class Foo
+
+    Delegate Function Func2() As Boolean
+End Class
+";
+
+                var expected = @"
+Friend Delegate Function Func1() As Boolean
+
+Friend Class Foo
+
+    Public Delegate Function Func2() As Boolean
+End Class
+";
+                Verify(text, expected, runFormatter: false, languageName: LanguageNames.VisualBasic);
+            }
+
             /// <summary>
             /// VB.Net can have visibility modifiers + explicit interface implementation unlike C#. The 
             /// visibility rules for these members is the same as normal members.

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/ExplicitVisibilityRule.VisualBasic.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/ExplicitVisibilityRule.VisualBasic.cs
@@ -164,7 +164,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
 
             public override SyntaxNode VisitDelegateStatement(DelegateStatementSyntax node)
             {
-                return EnsureVisibility(node, node.Modifiers, (x, l) => x.WithModifiers(l), () => SyntaxKind.PublicKeyword);
+                return EnsureVisibility(node, node.Modifiers, (x, l) => x.WithModifiers(l), () => GetDelegateTypeDefaultVisibility(node));
             }
 
             public override SyntaxNode VisitPropertyStatement(PropertyStatementSyntax node)


### PR DESCRIPTION
They were defaulting to always public.