### PR TITLE
Fix missing MSTestNamespaces.txt in output dir

### DIFF
--- a/src/XUnitConverter/XUnitConverter.csproj
+++ b/src/XUnitConverter/XUnitConverter.csproj
@@ -90,7 +90,9 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="MSTestNamespaces.txt" />
+    <Content Include="MSTestNamespaces.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />


### PR DESCRIPTION
MSTestNamespaces.txt should be copied to output directory if we want to use the tool from command line.

Fix #232 
