### PR TITLE
allow CodeFormatter to run on Mono

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,3 +235,6 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Local msbuild copy to run on Mono
+src/ExternalApis/

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+SRC="src"
+EXTERNAL_APIS_DIR="$SRC/ExternalApis"
+#see https://github.com/mono/msbuild/blob/xplat-c9/cibuild.sh
+MSBUILD_DOWNLOAD_URL="https://github.com/radical/msbuild/releases/download/v0.03/mono_msbuild_d25dd923839404bd64cc63f420e75acf96fc75c4.zip"
+MSBUILD_ZIP="$EXTERNAL_APIS_DIR/msbuild.zip"
+MSBUILD_EXE="$EXTERNAL_APIS_DIR/MSBuild/msbuild.exe"
+
+downloadMSBuildForMono()
+{
+    if [ ! -e "$MSBUILD_EXE" ]
+    then
+        mkdir -p $EXTERNAL_APIS_DIR
+
+        echo "** Downloading MSBUILD from $MSBUILD_DOWNLOAD_URL"
+        curl -sL -o $MSBUILD_ZIP "$MSBUILD_DOWNLOAD_URL"
+
+        unzip -q $MSBUILD_ZIP -d $EXTERNAL_APIS_DIR
+        find "$EXTERNAL_APIS_DIR/msbuild" -name "*.exe" -exec chmod "+x" '{}' ';'
+        rm $MSBUILD_ZIP
+    fi
+}
+
+downloadMSBuildForMono

--- a/src/CodeFormatter/App.config
+++ b/src/CodeFormatter/App.config
@@ -5,6 +5,7 @@
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <probing privatePath="./msbuild" />
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />

--- a/src/CodeFormatter/CodeFormatter.csproj
+++ b/src/CodeFormatter/CodeFormatter.csproj
@@ -105,6 +105,24 @@
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="CopyMSBuildForMono"
+          AfterTargets="AfterBuild"
+          Condition=" '$(OS)' == 'Unix' ">
+      <ItemGroup>
+          <_CopyItems Include="..\ExternalApis\msbuild\*.*" />
+      </ItemGroup>
+      <Copy
+          SourceFiles="@(_CopyItems)"
+          DestinationFolder="$(TargetDir)\msbuild"
+          />
+  </Target>
+  <Target Name="AfterClean"
+          Condition=" '$(OS)' == 'Unix' ">
+      <ItemGroup>
+          <LocalMonoMSBuild Include="$(TargetDir)\msbuild" />
+      </ItemGroup>
+      <RemoveDir Directories="@(LocalMonoMSBuild)" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
I would love to have a single source of truth for formatting C# code without any options to customize it. 

Turns out there is a CodeFormatter project (thank you!) but it doesn't run well on Mono. During MVPSummit Hackathon with **great help of @brettfo and guidance from @jaredpar ** we've been able to allow to run the CodeFormatter on mono with little changes.

How to run it on Mono then?
First, install the tools `sh init-tools.sh` (downloads and unzips MSBuild for Mono, one could possibly symlink to current install instead of downloading, idea taken from [Mono's MSBuild fork xplat-c9](https://github.com/mono/msbuild/blob/5c03c87120a7e8f03bbe40a386c738bbbe54ba4e/cibuild.sh)).

Restore NuGet packages and build the project: 
`nuget restore src/CodeFormattter.sln && msbuild src/CodeFormatter.sln` 

Then run it:
`mono bin/CodeFormatter/Debug/CodeFormatter.exe ../codeformatter-test/test.rsp`

Here's short video on overall process https://youtu.be/orPvC8y-Km4

Please let me know if there is a better way, I'm open for feedback.
The pull request is related to #106 