### PR TITLE
Split classes and Fix #264

### DIFF
--- a/src/CodeFormatter/CommandLineOptions.cs
+++ b/src/CodeFormatter/CommandLineOptions.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Immutable;
+
+namespace CodeFormatter
+{
+    public sealed class CommandLineOptions
+    {
+        public static readonly CommandLineOptions ListRules = new CommandLineOptions(
+            Operation.ListRules,
+            ImmutableArray<string[]>.Empty,
+            ImmutableArray<string>.Empty,
+            ImmutableDictionary<string, bool>.Empty,
+            ImmutableArray<string>.Empty,
+            ImmutableArray<string>.Empty,
+            null,
+            allowTables: false,
+            verbose: false);
+
+        public static readonly CommandLineOptions ShowHelp = new CommandLineOptions(
+            Operation.ShowHelp,
+            ImmutableArray<string[]>.Empty,
+            ImmutableArray<string>.Empty,
+            ImmutableDictionary<string, bool>.Empty,
+            ImmutableArray<string>.Empty,
+            ImmutableArray<string>.Empty,
+            null,
+            allowTables: false,
+            verbose: false);
+
+
+        public readonly Operation Operation;
+        public readonly ImmutableArray<string[]> PreprocessorConfigurations;
+        public readonly ImmutableArray<string> CopyrightHeader;
+        public readonly ImmutableDictionary<string, bool> RuleMap;
+        public readonly ImmutableArray<string> FormatTargets;
+        public readonly ImmutableArray<string> FileNames;
+        public readonly string Language;
+        public readonly bool AllowTables;
+        public readonly bool Verbose;
+
+        public CommandLineOptions(
+            Operation operation,
+            ImmutableArray<string[]> preprocessorConfigurations,
+            ImmutableArray<string> copyrightHeader,
+            ImmutableDictionary<string, bool> ruleMap,
+            ImmutableArray<string> formatTargets,
+            ImmutableArray<string> fileNames,
+            string language,
+            bool allowTables,
+            bool verbose)
+        {
+            Operation = operation;
+            PreprocessorConfigurations = preprocessorConfigurations;
+            CopyrightHeader = copyrightHeader;
+            RuleMap = ruleMap;
+            FileNames = fileNames;
+            FormatTargets = formatTargets;
+            Language = language;
+            AllowTables = allowTables;
+            Verbose = verbose;
+        }
+    }
+}

--- a/src/CodeFormatter/CommandLineParseResult.cs
+++ b/src/CodeFormatter/CommandLineParseResult.cs
@@ -1,0 +1,54 @@
+﻿using System.Diagnostics;
+
+namespace CodeFormatter
+{
+    public sealed class CommandLineParseResult
+    {
+        private readonly CommandLineOptions _options;
+        private readonly string _error;
+
+        public bool IsSuccess
+        {
+            get { return _options != null; }
+        }
+
+        public bool IsError
+        {
+            get { return !IsSuccess; }
+        }
+
+        public CommandLineOptions Options
+        {
+            get
+            {
+                Debug.Assert(IsSuccess);
+                return _options;
+            }
+        }
+
+        public string Error
+        {
+            get
+            {
+                Debug.Assert(IsError);
+                return _error;
+            }
+        }
+
+        private CommandLineParseResult(CommandLineOptions options = null, string error = null)
+        {
+            _options = options;
+            _error = error;
+        }
+
+        public static CommandLineParseResult CreateSuccess(CommandLineOptions options)
+        {
+            return new CommandLineParseResult(options: options);
+        }
+
+        public static CommandLineParseResult CreateError(string error)
+        {
+            return new CommandLineParseResult(error: error);
+        }
+    }
+}

--- a/src/CodeFormatter/Operation.cs
+++ b/src/CodeFormatter/Operation.cs
@@ -1,0 +1,9 @@
+﻿namespace CodeFormatter
+{
+    public enum Operation
+    {
+        Format = 0,
+        ListRules = 1,
+        ShowHelp = 2
+    }
+}


### PR DESCRIPTION
When I was resolving the #264 issue, I noted that the ```CommandLineParser.cs``` needed a small refactor, so I splited the file putting each class in its file.