### PR TITLE
Workspace Failed

### DIFF
--- a/src/CodeFormatter/Program.cs
+++ b/src/CodeFormatter/Program.cs
@@ -63,30 +63,32 @@ namespace CodeFormatter
 
         private static int RunFormat(CommandLineOptions options)
         {
-            var cts = new CancellationTokenSource();
-            var ct = cts.Token;
-
-            Console.CancelKeyPress += delegate { cts.Cancel(); };
-
-            try
+            using (var cts = new CancellationTokenSource())
             {
-                RunFormatAsync(options, ct).Wait(ct);
-                Console.WriteLine("Completed formatting.");
-                return 0;
-            }
-            catch (AggregateException ex)
-            {
-                var typeLoadException = ex.InnerExceptions.FirstOrDefault() as ReflectionTypeLoadException;
-                if (typeLoadException == null)
-                    throw;
+                var ct = cts.Token;
 
-                Console.WriteLine("ERROR: Type loading error detected. In order to run this tool you need either Visual Studio 2015 or Microsoft Build Tools 2015 tools installed.");
-                Console.WriteLine(typeLoadException.StackTrace);
-                var messages = typeLoadException.LoaderExceptions.Select(e => e.Message).Distinct();
-                foreach (var message in messages)
-                    Console.WriteLine("- {0}", message);
+                Console.CancelKeyPress += delegate { cts.Cancel(); };
 
-                return 1;
+                try
+                {
+                    RunFormatAsync(options, ct).Wait(ct);
+                    Console.WriteLine("Completed formatting.");
+                    return 0;
+                }
+                catch (AggregateException ex)
+                {
+                    var typeLoadException = ex.InnerExceptions.FirstOrDefault() as ReflectionTypeLoadException;
+                    if (typeLoadException == null)
+                        throw;
+
+                    Console.WriteLine("ERROR: Type loading error detected. In order to run this tool you need either Visual Studio 2015 or Microsoft Build Tools 2015 tools installed.");
+                    Console.WriteLine(typeLoadException.StackTrace);
+                    var messages = typeLoadException.LoaderExceptions.Select(e => e.Message).Distinct();
+                    foreach (var message in messages)
+                        Console.WriteLine("- {0}", message);
+
+                    return 1;
+                }
             }
         }
 


### PR DESCRIPTION
added a Workspace.WorkspaceFailed event handler so that if the input file cannot be processed, an error will be reported on the command line instead of failing silently