### PR TITLE
Do not trim spaces at the beginning in copyright header comment

### DIFF
--- a/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.CSharp.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.CSharp.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
 
             protected override SyntaxTrivia CreateLineComment(string commentText)
             {
-                return SyntaxFactory.Comment("// " + commentText);
+                return SyntaxFactory.Comment("//" + commentText);
             }
 
             protected override SyntaxTrivia CreateNewLine()

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.VisualBasic.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.VisualBasic.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
 
             protected override SyntaxTrivia CreateLineComment(string commentText)
             {
-                return SyntaxFactory.CommentTrivia("' " + commentText);
+                return SyntaxFactory.CommentTrivia("'" + commentText);
             }
 
             protected override SyntaxTrivia CreateNewLine()

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/CopyrightHeaderRule.cs
@@ -190,15 +190,15 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
         {
             if (line.StartsWith("'"))
             {
-                return line.Substring(1).TrimStart();
+                return line.Substring(1);
             }
 
             if (line.StartsWith("//"))
             {
-                return line.Substring(2).TrimStart();
+                return line.Substring(2);
             }
 
-            return line;
+            return " " + line;
         }
 
         public override bool SupportsLanguage(string languageName)


### PR DESCRIPTION
The copyright header rule trims spaces at the begginings of code comment lines. However, it does not perform the same operation for raw texts. That difference makes the rule think a code comment line and a raw text line different even if they are same. Such a raw text including a line beginning with spaces include Apache-2.0's copyright notice.

This change fixes the problem by removing the code trimming spaces. Additionally, this change takes spaces added when introducing new copyright headers into account.