### PR TITLE
Fix missing MSTestNamespaces.txt in output dir

### DIFF
--- a/src/XUnitConverter/XUnitConverter.csproj
+++ b/src/XUnitConverter/XUnitConverter.csproj
@@ -4,7 +4,9 @@
     <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="MSTestNamespaces.txt" />
+    <Content Include="MSTestNamespaces.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(MSBuildPackageVersion)" />


### PR DESCRIPTION
MSTestNamespaces.txt should be copied to output directory if we want to use the tool from command line.

Fix #232 and fix #246 